### PR TITLE
Fix bug in lifecycle command reporting.

### DIFF
--- a/fvirt/commands/_base/lifecycle.py
+++ b/fvirt/commands/_base/lifecycle.py
@@ -173,25 +173,25 @@ class LifecycleCommand(MatchCommand):
                     if state.fail_fast:
                         break
 
-                click.echo(f'Finished { op_help.continuous } specified { self.NAME }s.')
-                click.echo('')
-                click.echo('Results:')
-                click.echo(f'  Success:     { success }')
-                click.echo(f'  Failed:      { len(futures) - success }')
+            click.echo(f'Finished { op_help.continuous } specified { self.NAME }s.')
+            click.echo('')
+            click.echo('Results:')
+            click.echo(f'  Success:     { success }')
+            click.echo(f'  Failed:      { len(futures) - success }')
 
-                if skipped:
-                    click.echo(f'    Skipped:   { skipped }')
+            if skipped:
+                click.echo(f'    Skipped:   { skipped }')
 
-                if timed_out:
-                    click.echo(f'    Timed Out: { timed_out }')
+            if timed_out:
+                click.echo(f'    Timed Out: { timed_out }')
 
-                if forced:
-                    click.echo(f'    Forced:    { forced }')
+            if forced:
+                click.echo(f'    Forced:    { forced }')
 
-                click.echo(f'Total:         { len(futures) }')
+            click.echo(f'Total:         { len(futures) }')
 
-                if success != len(futures) or (not futures and state.fail_if_no_match):
-                    ctx.exit(ExitCode.FAILURE)
+            if success != len(futures) or (not futures and state.fail_if_no_match):
+                ctx.exit(ExitCode.FAILURE)
 
         params = tuple(params) + self.mixin_params(required=False)
 

--- a/tests/commands/pool/commands_pool_build_test.py
+++ b/tests/commands/pool/commands_pool_build_test.py
@@ -37,7 +37,6 @@ def test_command_run(
         pool.undefine()
 
 
-@pytest.mark.xfail(reason='Failing due to apparent bug in object matching code.')
 @pytest.mark.libvirtd
 def test_command_bulk_run(
     runner: Callable[[Sequence[str], int], Result],

--- a/tests/commands/volume/commands_volume_delete_test.py
+++ b/tests/commands/volume/commands_volume_delete_test.py
@@ -33,7 +33,6 @@ def test_command_run(runner: Callable[[Sequence[str], int], Result], live_volume
 
 
 @pytest.mark.libvirtd
-@pytest.mark.xfail(reason='Apparent bug in object matching code.')
 def test_command_bulk_run(
     runner: Callable[[Sequence[str], int], Result],
     live_pool: tuple[StoragePool, Hypervisor],

--- a/tests/commands/volume/commands_volume_wipe_test.py
+++ b/tests/commands/volume/commands_volume_wipe_test.py
@@ -48,7 +48,6 @@ def test_volume_wipe(
         vol.undefine()
 
 
-@pytest.mark.xfail(reason='Failing due to apparent internal bug in object matching code.')
 @pytest.mark.libvirtd
 @pytest.mark.slow
 def test_command_bulk_run(


### PR DESCRIPTION
This was ultimately the root cause of a number of failing tests.