### PR TITLE
General improvements to test reliability.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -292,6 +292,17 @@ flake8 = ">=3"
 develop = ["build", "twine"]
 
 [[package]]
+name = "flaky"
+version = "3.7.0"
+description = "Plugin for nose or pytest that automatically reruns flaky tests."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "flaky-3.7.0-py2.py3-none-any.whl", hash = "sha256:d6eda73cab5ae7364504b7c44670f70abed9e75f77dd116352f662817592ec9c"},
+    {file = "flaky-3.7.0.tar.gz", hash = "sha256:3ad100780721a1911f57a165809b7ea265a7863305acb66708220820caf8aa0d"},
+]
+
+[[package]]
 name = "frozendict"
 version = "2.3.8"
 description = "A simple immutable dictionary"
@@ -1108,4 +1119,4 @@ dev = ["doc8", "flake8", "flake8-import-order", "rstcheck[sphinx]", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "53f911a704117483d6532ad9adc4153b5d2f625215a375b5f4826ac5d42211d5"
+content-hash = "c3a7efde85d9c6c7e0a42922bcf27dd2da7e4050faffbe1c89254bb4de48c5f5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ flake8-debug = "^0.2.0"
 flake8-isort = "^6.1.0"
 flake8-quotes = "^3.3.2"
 flake8-sfs = "^0.0.4"
+flaky = "^3.7.0"
 isort = "^5.12.0"
 lxml-stubs = "^0.4.0"
 mypy = "^1.6.1"
@@ -81,7 +82,7 @@ skip_gitignore = true
 use_parentheses = true
 
 [tool.pytest.ini_options]
-addopts = "-n logical --dist worksteal"
+addopts = "-n logical --dist worksteal --force-flaky --no-flaky-report"
 minversion = 7.0
 markers = [
     "slow: marks tests which may take a long time to run",

--- a/tests/commands/domain/commands_domain_shutdown_test.py
+++ b/tests/commands/domain/commands_domain_shutdown_test.py
@@ -25,15 +25,15 @@ if TYPE_CHECKING:
     (
         tuple(),
         0,
-        5,
+        15,
     ),
     (
         ('--timeout', '0'),
         int(ExitCode.OPERATION_FAILED),
-        5,
+        15,
     ),
     (
-        ('--timeout', '5'),
+        ('--timeout', '15'),
         0,
         0,
     ),
@@ -53,6 +53,7 @@ def test_command_run(
     '''Test that the command runs correctly.'''
     dom, hv = live_dom
     uri = str(hv.uri)
+    iter_delay = 0.2
 
     dom.start(idempotent=True)
 
@@ -63,13 +64,13 @@ def test_command_run(
     result = runner(('-c', uri, 'domain', 'shutdown', dom.name) + opts, expected)
     assert len(result.output) > 0
 
-    t = 0
+    t = 0.0
     while t < delay:
         if not dom.running:
             break
 
-        t += 1
-        sleep(1)
+        t += iter_delay
+        sleep(iter_delay)
 
     assert dom.running == False  # noqa: E712
 
@@ -93,12 +94,12 @@ def test_command_bulk_run(
     result = runner(('-c', uri, 'domain', 'shutdown', '--match', 'name', object_name_prefix), 0)
     assert len(result.output) > 0
 
-    t = 0
-    while t < 10:
+    t = 0.0
+    while t < 15:
         if all((not dom.running) for dom in doms):
             break
 
-        t += 1
-        sleep(1)
+        t += 0.2
+        sleep(0.2)
 
     assert all((not dom.running) for dom in doms)

--- a/tests/libvirt/libvirt_domain_test.py
+++ b/tests/libvirt/libvirt_domain_test.py
@@ -311,7 +311,7 @@ def test_shutdown_timeouts(test_dom: tuple[Domain, Hypervisor]) -> None:
     ),
     (
         {
-            'timeout': 5,
+            'timeout': 15,
             'force': False,
         },
         LifecycleResult.SUCCESS,
@@ -323,7 +323,7 @@ def test_shutdown_timeouts(test_dom: tuple[Domain, Hypervisor]) -> None:
             'force': False,
         },
         LifecycleResult.SUCCESS,
-        5,
+        15,
     ),
     (
         {
@@ -331,7 +331,7 @@ def test_shutdown_timeouts(test_dom: tuple[Domain, Hypervisor]) -> None:
             'force': False,
         },
         LifecycleResult.TIMED_OUT,
-        5,
+        15,
     ),
     (
         {
@@ -345,6 +345,7 @@ def test_shutdown_timeouts(test_dom: tuple[Domain, Hypervisor]) -> None:
 def test_live_shutdown(opts: Mapping[str, Any], expected: LifecycleResult, delay: int, live_dom: tuple[Domain, Hypervisor]) -> None:
     '''Check that shutting down a domain works.'''
     dom, _ = live_dom
+    iter_delay = 0.2
 
     dom.start(idempotent=True)
 
@@ -357,13 +358,13 @@ def test_live_shutdown(opts: Mapping[str, Any], expected: LifecycleResult, delay
     assert isinstance(result, LifecycleResult)
     assert result == expected
 
-    t = 0
+    t = 0.0
     while t < delay:
         if not dom.running:
             break
 
-        t += 1
-        sleep(1)
+        t += iter_delay
+        sleep(iter_delay)
 
     assert dom.running == False  # noqa: E712
 


### PR DESCRIPTION
- Add flaky to rerun failed tests automatically.
- Extend internal timeouts on domain shutdown tests, but reduce polling interval.