### PR TITLE
Improve fvirt.libvirt.models models to provide far better schemas.

### DIFF
--- a/fvirt/libvirt/models/_types.py
+++ b/fvirt/libvirt/models/_types.py
@@ -5,10 +5,35 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Self, Type
+import datetime
+import math
 
-from pydantic import GetCoreSchemaHandler
+from typing import Annotated, Any, ClassVar, Final, Self, Type
+
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, GetCoreSchemaHandler
 from pydantic_core import core_schema
+
+ISO_8601_PATTERN: Final = r'^\d{4}-(\d{2}-\d{2}|W\d{2}-\d)[T ][0-2]\d:[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$'
+
+
+class Model(BaseModel):
+    '''Custom base class for models with modified default config.'''
+    model_config: ClassVar = ConfigDict(
+        allow_inf_nan=False,
+    )
+
+
+NetPort = Annotated[int, Field(gt=0, lt=65536)]
+NonEmptyString = Annotated[str, Field(min_length=1)]
+FilePath = Annotated[str, Field(pattern=r'^/.+$')]
+FileMode = Annotated[str, Field(pattern=r'^0[0-7]{3}$')]
+Hostname = Annotated[str, Field(
+    pattern=r'^[a-zA-Z0-9-]{1,63}(\.[a-zA-Z0-9-]{1,63})*\.?$',
+    max_length=253,
+    json_schema_extra={
+        'format': 'hostname',
+    },
+)]
 
 
 class CustomBool:
@@ -30,17 +55,25 @@ class CustomBool:
        This class provides the required machinery to be used with Pydantic.'''
     TRUE_STR: ClassVar[str] = ''
     FALSE_STR: ClassVar[str] = ''
+    __slots__ = (
+        '__value',
+    )
 
-    def __init__(self: Self, value: Any) -> None:
+    def __init__(self: Self, value: bool | str | CustomBool) -> None:
         if not self.TRUE_STR or not self.FALSE_STR:
             raise NotImplementedError
 
-        if value == self.TRUE_STR:
-            self.__value = True
-        elif value == self.FALSE_STR:
-            self.__value = False
-        else:
-            self.__value = bool(value)
+        match value:
+            case bool():
+                self.__value = value
+            case CustomBool():
+                self.__value = bool(value)
+            case self.TRUE_STR:
+                self.__value = True
+            case self.FALSE_STR:
+                self.__value = False
+            case _:
+                raise ValueError(value)
 
     def __hash__(self: Self) -> int:
         return hash(self.__value)
@@ -53,6 +86,17 @@ class CustomBool:
             return self.TRUE_STR
 
         return self.FALSE_STR
+
+    def __eq__(self: Self, other: Any) -> bool:
+        match other:
+            case bool():
+                return bool(self) == other
+            case str():
+                return str(self) == other
+            case CustomBool():
+                return bool(self) == bool(other)
+            case _:
+                return False
 
     @classmethod
     def __get_pydantic_core_schema__(
@@ -76,22 +120,7 @@ class CustomBool:
                     ),
                 ],
             ),
-            python_schema=core_schema.union_schema(
-                [
-                    core_schema.literal_schema(
-                        expected=[
-                            cls.TRUE_STR,
-                            cls.FALSE_STR,
-                        ],
-                    ),
-                    core_schema.bool_schema(
-                        strict=True,
-                    ),
-                    core_schema.is_subclass_schema(
-                        cls=CustomBool,
-                    ),
-                ],
-            ),
+            python_schema=core_schema.is_instance_schema(source),
             serialization=core_schema.plain_serializer_function_ser_schema(
                 bool,
                 info_arg=False,
@@ -107,7 +136,120 @@ class YesNo(CustomBool):
     FALSE_STR = 'no'
 
 
+V_YesNo = Annotated[YesNo, BeforeValidator(lambda v, i: YesNo(v))]
+
+
 class OnOff(CustomBool):
     '''A boolean that is represented in XML as either 'on' or 'off'.'''
     TRUE_STR = 'on'
     FALSE_STR = 'off'
+
+
+V_OnOff = Annotated[OnOff, BeforeValidator(lambda v, i: OnOff(v))]
+
+
+class Timestamp:
+    '''Custom timestamp class that provides direct formatting for use with libvirt XML.
+
+       The constructor takes either an string consisting of
+       an ISO 8601 timestamp that would be accepted by Python's
+       datetime.datetime.fromisoformat() method, an integral number
+       of seconds since the epoch in UTC, an existing Python
+       datetime.datetime instance, or an existing datetime.date instance
+       (in which case the time will be set to midnight UTC on that day).
+
+       The timestamp is internally normalized to UTC, and all output
+       will utilize the UTC time it represents (this is required by a
+       number of things in libvirt domain XML). Note that this handles
+       naive datetime.datetime instnaces just like the underlying Python
+       standard library does, so it is strongly recommended to use aware
+       datetime.datetime instances.
+
+       Converting to an integer will produce an integral number of
+       seconds since the epoch in UTC, truncating any microseconds.
+
+       Converting to a float will also give the number of seconds since
+       the epoch in UTC, but microseconds will be converted to fractional
+       seconds.
+
+       Converting to a string will produce an ISO 8601-compliant timestamp
+       _without a timezone_, representing the time in UTC.
+
+       This class provides the required machinery to be used with Pydantic.'''
+    __slots__ = (
+        '__value',
+    )
+
+    def __init__(self: Self, tstamp: int | str | datetime.datetime | datetime.date = datetime.datetime.now()) -> None:
+        match tstamp:
+            case int():
+                self.__value = datetime.datetime.fromtimestamp(tstamp, datetime.timezone.utc)
+            case str():
+                self.__value = datetime.datetime.fromisoformat(tstamp)
+
+                if self.__value.tzinfo is None:
+                    self.__value = datetime.datetime(
+                        year=self.__value.year,
+                        month=self.__value.month,
+                        day=self.__value.day,
+                        hour=self.__value.hour,
+                        minute=self.__value.minute,
+                        second=self.__value.second,
+                        microsecond=self.__value.microsecond,
+                        fold=self.__value.fold,
+                        tzinfo=datetime.timezone.utc,
+                    )
+            case datetime.datetime():
+                self.__value = datetime.datetime.astimezone(tstamp, datetime.timezone.utc)
+            case datetime.date():
+                self.__value = datetime.datetime(
+                    year=tstamp.year,
+                    month=tstamp.month,
+                    day=tstamp.day,
+                    hour=0,
+                    minute=0,
+                    second=0,
+                    microsecond=0,
+                    fold=0,
+                    tzinfo=datetime.timezone.utc,
+                )
+            case _:
+                raise ValueError
+
+    def __int__(self: Self) -> int:
+        return math.trunc(self.__value.timestamp())
+
+    def __float__(self: Self) -> float:
+        return self.__value.timestamp()
+
+    def __str__(self: Self) -> str:
+        return self.__value.strftime('%Y-%m-%dT%H:%M:%S')
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls: Type[Self],
+        source: Type[Any],
+        handler: GetCoreSchemaHandler,
+    ) -> core_schema.CoreSchema:
+        assert source is cls
+
+        return core_schema.json_or_python_schema(
+            json_schema=core_schema.union_schema(
+                [
+                    core_schema.str_schema(
+                        pattern=ISO_8601_PATTERN,
+                        strict=True,
+                    ),
+                    core_schema.int_schema(
+                        strict=True,
+                    ),
+                ],
+            ),
+            python_schema=core_schema.is_instance_schema(Timestamp),
+            serialization=core_schema.to_string_ser_schema(
+                when_used='json-unless-none',
+            ),
+        )
+
+
+V_Timestamp = Annotated[Timestamp, BeforeValidator(lambda v, i: Timestamp(v))]

--- a/fvirt/libvirt/models/domain.py
+++ b/fvirt/libvirt/models/domain.py
@@ -15,81 +15,75 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from ipaddress import IPv4Address, IPv6Address
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 from uuid import UUID
 
-from psutil import cpu_count
-from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
+from pydantic import Field, ValidationInfo, computed_field, field_validator, model_validator
 from pydantic_extra_types.mac_address import MacAddress
 
-YES_NO = Literal['yes', 'no']
-ON_OFF = Literal['on', 'off']
-CHARDEV_SRC_TYPE = Literal['stdio', 'file', 'vc', 'null', 'pty', 'dev', 'pipe', 'tcp', 'unix', 'spiceport', 'nmdm']
+from ._types import FileMode, FilePath, Hostname, Model, NetPort, NonEmptyString, V_OnOff, V_Timestamp, V_YesNo
 
 
-def _check_char_dev_src(src_type: CHARDEV_SRC_TYPE, src: CharDevSource | None) -> None:
-    require_attrs = set()
-
-    match src_type:
-        case 'stdio' | 'vc' | 'null':
-            if src is not None:
-                raise ValueError(f'Source may not be specified for a type of "{ src_type }".')
-        case 'pty':
-            if src is not None:
-                require_attrs = {
-                    'path',
-                }
-        case 'file' | 'dev' | 'pipe' | 'nmdm':
-            require_attrs = {
-                'path',
-            }
-        case 'tcp':
-            require_attrs = {
-                'host',
-                'service',
-            }
-        case 'unix':
-            require_attrs = {
-                'path',
-                'mode',
-            }
-        case 'spiceport':
-            require_attrs = {
-                'channel',
-            }
-
-    if require_attrs and src is None:
-        raise ValueError(f'Source must be specified for a type of "{ src_type }".')
-
-    for attr in require_attrs:
-        if getattr(src, attr) is None:
-            raise ValueError(f'Source attribute "{ attr }" must be specified for a type of "{ src_type }".')
-
-
-class PCIAddress(BaseModel):
+class PCIAddress(Model):
     '''Model representing a PCI address.'''
-    bus: str = Field(pattern='^0x[0-9a-f]{2}$')
-    slot: str = Field(pattern='^0x[0-9a-f]{2}$')
-    function: str = Field(default='0x0', pattern='^0x[0-9a-f]$')
-    domain: str | None = Field(default=None, pattern='^0x[0-9a-f]{4}$')
-    multifunction: str | None = Field(default=None, pattern='^(on|off)$')
+    bus: Annotated[str, Field(pattern='^0x[0-9a-f]{2}$')] | Annotated[int, Field(ge=0x00, le=0xff)] = Field(
+        description='The PCI bus used for this PCI address.',
+    )
+    slot: Annotated[str, Field(pattern='^0x[01][0-9a-f]$')] | Annotated[int, Field(ge=0x00, le=0x1f)] = Field(
+        description='The PCI device on the specified bus.',
+    )
+    function: Annotated[str, Field(pattern='^0x[0-7]$')] | Annotated[int, Field(ge=0x0, le=0x7)] = Field(
+        default='0x0',
+        description='The function of the specified device.',
+    )
+    domain: Annotated[str, Field(pattern='^0x[0-9a-f]{4}$')] | Annotated[int, Field(ge=0x0000, le=0xffff)] | None = Field(
+        default=None,
+        description='The PCI domain used for this PCI address.',
+    )
+    multifunction: V_OnOff | None = Field(
+        default=None,
+        description='Whether to enable multifunction support for this device. Requires QEMU.',
+    )
 
 
-class DriveAddress(BaseModel):
+class DriveAddress(Model):
     '''Model representing a 'drive' address.'''
-    controller: int | None = Field(default=None, ge=0)
-    bus: int = Field(default=0, ge=0)
-    target: int = Field(default=0, ge=0)
-    unit: int = Field(default=0, ge=0)
+    controller: int | None = Field(
+        default=None,
+        ge=0,
+        description='Index of the controller to use for this drive. If not specified, libvirt will infer a correct value.',
+    )
+    bus: int = Field(
+        default=0,
+        ge=0,
+        description='Bus number for this drive.',
+    )
+    target: int = Field(
+        default=0,
+        ge=0,
+        description='Target index for this drive.',
+    )
+    unit: int = Field(
+        default=0,
+        ge=0,
+        description='Unit index for this drive.',
+    )
 
 
-class DataRate(BaseModel):
+class DataRate(Model):
     '''Model representing a data transfer rate.'''
-    bytes: int = Field(gt=0)
-    period: int | None = Field(default=None, gt=0)
+    bytes: int = Field(
+        gt=0,
+        description='Number of bytes that can be transferred in the specified period.',
+    )
+    period: int = Field(
+        default=1000,
+        gt=0,
+        description='The size of the time window for the limit, specified in miliseconds.',
+    )
 
 
-class MemtuneInfo(BaseModel):
+class MemtuneInfo(Model):
     '''Model representing the contents of a <memtune> element in domain XML.
 
        `hard` is the hard memory limit.
@@ -101,10 +95,26 @@ class MemtuneInfo(BaseModel):
        `min` is the minimum memory guarantee.
 
        All values are expressed as bytes. A value of None indicates no limit.'''
-    hard: int | None = Field(default=None, gt=0)
-    soft: int | None = Field(default=None, gt=0)
-    swap: int | None = Field(default=None, gt=0)
-    min: int | None = Field(default=None, gt=0)
+    hard: int | None = Field(
+        default=None,
+        gt=0,
+        description='Hard limit on host-side domain memory usage in bytes.',
+    )
+    soft: int | None = Field(
+        default=None,
+        gt=0,
+        description='Soft limit on host-side domain memory usage in bytes.',
+    )
+    swap: int | None = Field(
+        default=None,
+        gt=0,
+        description='Hard limit on host-side domain memory and swap usage in bytes.',
+    )
+    min: int | None = Field(
+        default=None,
+        gt=0,
+        description='Minimum amount of host-side memory available to domain, in bytes.',
+    )
 
     @model_validator(mode='after')
     def check_limits(self: Self) -> Self:
@@ -114,7 +124,7 @@ class MemtuneInfo(BaseModel):
         return self
 
 
-class CPUModelInfo(BaseModel):
+class CPUModelInfo(Model):
     '''Model representing the <model> element of the <cpu> element in domain XML.
 
        `name` is the name of the CPU model to use.
@@ -122,43 +132,45 @@ class CPUModelInfo(BaseModel):
        `fallback` defines the fallback behavior for the CPU model
        handling. A value of None means to use the default fallback
        behavior.'''
-    name: str = Field(min_length=1)
-    fallback: str | None = Field(default=None, min_length=1)
+    name: NonEmptyString = Field(
+        description='Name of the CPU model. Valid values depend on the domain CPU architecture and the domain type.',
+    )
+    fallback: Literal['allow', 'forbid'] | None = Field(
+        default=None,
+        description='Specify fallback behavior if the requested CPU model cannot be used.',
+    )
 
 
-class CPUTopology(BaseModel):
-    '''Model representing the CPU topology for a domain.
-
-       If `infer` is set to a value of 'threads', the threads property
-       will be automatically inferred from system topology if possible
-       using psutil.cpu_count(). This is useful for VMs which will have
-       their vcpus pinned to specific host CPUs.
-
-       `coalesce` indicates what level of topology the automatic fixup
-       based on vcpus should happen at. If the topology does not match the
-       number of vcpus, then the properties other than the one specified
-       by `coalesce` will be set to 1 and the property specified by
-       `coalesce` will be set to the number of vcpus. A value of None
-       for `coalesce` will try to minimize how many properties need to
-       be reset. If not using pinned vcpus, a value of 'sockets' is
-       recommended for `coalesce`.'''
-    infer: Literal['threads'] | None = Field(default=None)
-    coalesce: Literal['sockets', 'dies', 'cores', 'threads'] | None = Field(default=None)
-    sockets: int = Field(default=1, gt=0)
-    dies: int = Field(default=1, gt=0)
-    cores: int = Field(default=1, gt=0)
-    threads: int = Field(default=1, gt=0)
-
-    @model_validator(mode='after')
-    def infer_values(self: Self) -> Self:
-        if self.infer == 'threads':
-            lcpus = cpu_count(logical=True)
-            pcpus = cpu_count(logical=False)
-
-            if lcpus is not None and pcpus is not None:
-                self.threads = lcpus // pcpus
-
-        return self
+class CPUTopology(Model):
+    '''Model representing the CPU topology for a domain.'''
+    coalesce: Literal['sockets', 'dies', 'cores', 'threads'] | None = Field(
+        default=None,
+        description='Controls topology fixup behavior. If the topology does not match the number of VCPUs ' +
+                    'assigned to the domain, the specified property will be set to the number of VCPUs ' +
+                    'assigned to the domain and the other properties will be set to 1. If unspecified or null, ' +
+                    'finer-grained properties will be preserved to the greatest etent possible. If not using ' +
+                    "pinned VCPUs, a value of 'sockets' is recommended.",
+    )
+    sockets: int = Field(
+        default=1,
+        gt=0,
+        description='The number of CPU sockets the system should have.',
+    )
+    dies: int = Field(
+        default=1,
+        gt=0,
+        description='The number of dies per CPU socket.',
+    )
+    cores: int = Field(
+        default=1,
+        gt=0,
+        description='The number of physical CPU cores per die.',
+    )
+    threads: int = Field(
+        default=1,
+        gt=0,
+        description='The number of logical CPUs per CPU core.',
+    )
 
     @property
     def total_cpus(self: Self) -> int:
@@ -208,328 +220,329 @@ class CPUTopology(BaseModel):
             setattr(self, self.coalesce, vcpus)
 
 
-class CPUInfo(BaseModel):
+class CPUInfo(Model):
     '''Model representing the contents of the <cpu> element in domain XML.
 
        `mode` indicates the value for the `mode` attribute of the
        element. A value of None means to use the default defined by
-       the templates.
-
-       `model` is an optional CPUModelInfo instance desribing the <model>
-       element. A value of None means this element will be omitted in
-       the config.
-
-       `sockets` indicates the number of CPU sockets to use.
-
-       `dies` indicates the number of dies per CPU socket to use.
-
-       `cores` indicates the number of CPU cores per die to use.
-
-       `threads` indicates the number of threads per CPU core to use.'''
-    mode: str | None = Field(default=None, min_length=1)
-    model: CPUModelInfo | None = Field(default=None)
-    topology: CPUTopology = Field(default_factory=CPUTopology)
+       the templates.'''
+    mode: Literal['custom', 'host-model', 'host-passthrough', 'maximum'] | None = Field(
+        default=None,
+        description='The CPU emulation handling mode to use. If left unset, a sane default will be used based on the domain type.',
+    )
+    model: CPUModelInfo | None = Field(
+        default=None,
+        description='CPU model configuration for the domain.',
+    )
+    topology: CPUTopology = Field(
+        default_factory=CPUTopology,
+        description='CPU topology configuration for the domain. If left unset, a sane default will be inferred based on the number ' +
+                    'of VCPUs assigned to the domain.',
+    )
 
 
-class OSFWLoaderInfo(BaseModel):
+class OSFWLoaderInfo(Model):
     '''Model representing the contents of a <loader> element in an <os> element when in firmware mode.
 
        `path` specifies the path to the loader file. A value of None
        requests for the hypervisor to autoselect firmware.
 
        The remaining attributes specifiy values for the corresponding
-       attributes on the <loader> element. A value of None '''
-    path: str | None = Field(default=None, min_length=1)
-    readonly: YES_NO | None = Field(default=None)
-    secure: YES_NO | None = Field(default=None)
-    stateless: YES_NO | None = Field(default=None)
-    type: str | None = Field(default=None, min_length=1)
+       attributes on the <loader> element. A value of None indicates
+       that attribute should not be included.'''
+    path: FilePath | None = Field(
+        default=None,
+        description='The path to the firmware file that should be used. If not specified, the hypervisor will autoselect appropriate firmware.',
+    )
+    readonly: V_YesNo | None = Field(
+        default=None,
+        description='Whether the firmware image should be read-only or not.',
+    )
+    secure: V_YesNo | None = Field(
+        default=None,
+        description='Whether the firmware is secure-boot capable or not.',
+    )
+    stateless: V_YesNo | None = Field(
+        default=None,
+        description='Whether stateless mode should be used or not.',
+    )
+    type: Literal['rom', 'pflash'] | None = Field(
+        default=None,
+        description='Indicates how the firmware should be exposed to the guest.',
+    )
 
 
-class OSFWNVRAMInfo(BaseModel):
+class OSFWNVRAMInfo(Model):
     '''Model representing the contents of a <nvram> element in an <os> element when in firmware mode.
 
-       Currently, this only supports templated NVRAM file generation.
+       Currently, this only supports templated NVRAM file generation.'''
+    path: FilePath = Field(
+        description='The path to use for the NVRAM image.',
+    )
+    template: FilePath = Field(
+        description='The path to the template to use when generating the NVRAM image.'
+    )
 
-       `path` specifies the path to the NVRAM file.
 
-       `template` specifies the template file to use.'''
-    path: str = Field(min_length=1)
-    template: str = Field(min_length=1)
-
-
-class OSContainerIDMapEntry(BaseModel):
+class OSContainerIDMapEntry(Model):
     '''Model representing an idmap entry for the <os> element in domain configuration.
 
        `target` and `count` correspond to those attributes on the subelements of the <idmap> element.'''
-    target: int = Field(ge=0)
-    count: int = Field(gt=0)
+    target: int = Field(
+        ge=0,
+        description='Specifies the first target ID to use for ID mapping.',
+    )
+    count: int = Field(
+        gt=0,
+        description='Specifies how many IDs to map.',
+    )
 
 
-class OSContainerIDMapInfo(BaseModel):
+class OSContainerIDMapInfo(Model):
     '''Model representing the <idmap> element in the <os> element in domain configuration.
 
        The `uid` and `gid` properties correspond to those specific
        sub-elements of the <idmap> element.'''
-    uid: OSContainerIDMapEntry
-    gid: OSContainerIDMapEntry
+    uid: OSContainerIDMapEntry = Field(
+        description='Specifies ID mapping parameters for user IDs.',
+    )
+    gid: OSContainerIDMapEntry = Field(
+        description='Specifies ID mapping parameters for group IDs.',
+    )
 
 
-class OSInfo(BaseModel):
-    '''Model representing the <os> element in domain configuration.
+class _BaseOSInfo(Model):
+    arch: NonEmptyString | None = Field(
+        default=None,
+        description='The CPU architecture to use for this domain. Accepted values vary based on the domain type.',
+    )
+    machine: NonEmptyString | None = Field(
+        default=None,
+        description='The machine type to use for this domain. Accepted values vary based on the domain type.',
+    )
+    type: NonEmptyString | None = Field(
+        default=None,
+        description='The guest type to be used with this domain. Accepted values vary based on the domain type.',
+    )
+
+
+class OSFirmwareInfo(_BaseOSInfo):
+    '''Model representing a guest firwmare boot setup.
 
        `firmware` corresponds to the attribute of the same name on the
-       <os> element.
-
-       `variant` identifies the specific type of OS configuration to
-       use. It is not directly represented on template output, but
-       dictates what structure to use when templating.
-
-       A value of `firmware` for `variant` indicates a conventional
-       bootloader setup. The `loader` property must be a OSFWLoaderInfo
-       instance if present, and only it and the `nvram` property are
-       honored.
-
-       A value of `host` for `variant` indicates use of a host-side
-       bootloader, such as Xen’s pygrub or Bhyve’s bhyveload. The
-       `bootloader` property must be a string pointing to a usable command
-       for this purpose, and the optional `bootloader_args` property
-       specifies any extra arguments to pass to that command. Only those
-       two properties are honored.
-
-       A value of 'direct` for `variant` indicates use of direct kernel
-       boot. The `loader`, `kernel`, `initrd`, `cmdline`, and `dtb`
-       properties directly correspond to the values for those elements
-       under the <os> element in this case, and the `kernel` property
-       is required.
-
-       A value of `container` for `variant` indicates a container boot
-       setup. The `init` property specifies the executable to use for
-       initialization. The `initargs` property is an optional sequence
-       of additional arguments to pass to the `init` executable. The
-       `initenv` property is an optional mapping indicating environment
-       variables to use with the `init` program. The optional `initdir`,
-       `inituser`, and `initgroup` propertyies specify the working
-       directory, user, and group IDs to use when running the `init`
-       program. The optional `idmap` property indicates ID mapping
-       behavior to use.
-
-       A value of `test` for `variant` indicates the minimal OS setup
-       used for domains defined for the libvirt test driver.
-
-       The optional `arch` property specifies the CPU architecture for
-       the domain. A value of None indicates that this is unspecified.
-
-       The optional `machine` property specifies the emulated machine
-       model for the domain. A value of None indicates that this is
-       unspecified.
-
-       The optional `type` property specifies the type of domain, such
-       as hvm or pv. A value of None indicates to use a sensible default
-       for this.'''
-    variant: str = Field(pattern='^(firmware|host|direct|container|test)$')
-    firmware: str | None = Field(default=None, min_length=1)
-    arch: str | None = Field(default=None, min_length=1)
-    machine: str | None = Field(default=None, min_length=1)
-    type: str | None = Field(default=None, min_length=1)
-    loader: OSFWLoaderInfo | str | None = Field(default=None)
-    nvram: OSFWNVRAMInfo | None = Field(default=None)
-    bootloader: str | None = Field(default=None, min_length=1)
-    bootloader_args: str | None = Field(default=None)
-    kernel: str | None = Field(default=None, min_length=1)
-    initrd: str | None = Field(default=None, min_length=1)
-    cmdline: str | None = Field(default=None, min_length=1)
-    dtb: str | None = Field(default=None, min_length=1)
-    init: str | None = Field(default=None, min_length=1)
-    initargs: Sequence[str] = Field(default_factory=list)
-    initenv: Mapping[str, str] = Field(default_factory=dict)
-    initdir: str | None = Field(default=None, min_length=1)
-    inituser: str | None = Field(default=None, min_length=1)
-    initgroup: str | None = Field(default=None, min_length=1)
-    idmap: OSContainerIDMapInfo | None = Field(default=None)
+       <os> element.'''
+    variant: Literal['firmware']
+    firmware: NonEmptyString | None = Field(
+        default=None,
+        description='Specifies the type of firmware to use for auto-selection.',
+    )
+    loader: OSFWLoaderInfo | None = Field(
+        default=None,
+        description='Configuration for the guest firmware. If not specified, default firmware will be used.',
+    )
+    nvram: OSFWNVRAMInfo | None = Field(
+        default=None,
+        description="Configuration for the guest NVRAM. If this is specified, the 'loader' property must also be specified.",
+    )
 
     @model_validator(mode='after')
-    def check_variant(self: Self) -> Self:
-        match self.variant:
-            case 'firmware':
-                if isinstance(self.loader, str):
-                    raise ValueError('Loader must be an OSFWLoaderInfo instance for variant "firmware".')
-
-                if self.nvram is not None and self.loader is None:
-                    raise ValueError('NVRAM may only be specified if loader is also specified.')
-
-                invalid_props = {
-                    'bootloader',
-                    'bootloader_args',
-                    'kernel',
-                    'initrd',
-                    'cmdline',
-                    'dtb',
-                    'init',
-                    'initargs',
-                    'initenv',
-                    'initdir',
-                    'inituser',
-                    'initgroup',
-                    'idmap',
-                }
-            case 'host':
-                if self.bootloader is None:
-                    raise ValueError('Bootloader must be specified for variant "host".')
-
-                invalid_props = {
-                    'loader',
-                    'nvram',
-                    'kernel',
-                    'initrd',
-                    'cmdline',
-                    'dtb',
-                    'init',
-                    'initargs',
-                    'initenv',
-                    'initdir',
-                    'inituser',
-                    'initgroup',
-                    'idmap',
-                }
-            case 'direct':
-                if isinstance(self.loader, OSFWLoaderInfo):
-                    raise ValueError('Loader must be a string for variant "direct".')
-
-                if self.kernel is None:
-                    raise ValueError('Kernel must be specified for variant "direct".')
-
-                invalid_props = {
-                    'nvram',
-                    'bootloader',
-                    'bootloader_args',
-                    'init',
-                    'initargs',
-                    'initenv',
-                    'initdir',
-                    'inituser',
-                    'initgroup',
-                    'idmap',
-                }
-            case 'container':
-                if self.init is None or not self.init:
-                    raise ValueError('"init" properrty must be defined for variant "container".')
-
-                invalid_props = {
-                    'loader',
-                    'nvram',
-                    'bootloader',
-                    'bootloader_args',
-                    'kernel',
-                    'initrd',
-                    'cmdline',
-                    'dtb',
-                }
-            case 'test':
-                if self.arch is None:
-                    raise ValueError('"arch" property must be defined for variant "test".')
-
-                invalid_props = {
-                    'loader',
-                    'nvram',
-                    'bootloader',
-                    'bootloader_args',
-                    'kernel',
-                    'initrd',
-                    'cmdline',
-                    'dtb',
-                    'init',
-                    'initargs',
-                    'initenv',
-                    'initdir',
-                    'inituser',
-                    'initgroup',
-                    'idmap',
-                }
-            case _:
-                raise RuntimeError
-
-        for item in invalid_props:
-            if getattr(self, item):
-                raise ValueError(f'"{ item }" property is not valid for variant "{ self.variant }".')
+    def check_nvram(self: Self) -> Self:
+        if self.nvram is not None and self.loader is None:
+            raise ValueError('NVRAM may only be specified if loader is also specified.')
 
         return self
 
 
-class ClockTimerInfo(BaseModel):
+class OSHostBootInfo(_BaseOSInfo):
+    '''Model representing a host bootloader setup, such as might be used witn Xen.'''
+    variant: Literal['host']
+    bootloader: FilePath = Field(
+        description='Path to the bootloader executable on the host system.',
+    )
+    bootloader_args: str | None = Field(
+        default=None,
+        description='Arguments to pass to the bootloader.',
+    )
+
+
+class OSDirectBootInfo(_BaseOSInfo):
+    '''Model representing a direct kernel boot setup.'''
+    variant: Literal['direct']
+    kernel: FilePath = Field(
+        description='Path to the guest kernel image on the host system.',
+    )
+    loader: FilePath | None = Field(
+        default=None,
+        description='Path to firmware image to use to initialize the guest hardware.',
+    )
+    initrd: FilePath | None = Field(
+        default=None,
+        description='Path to the guest initrd/initramfs image on the host system.',
+    )
+    cmdline: str | None = Field(
+        default=None,
+        description='Command line arguments to pass to the guest kernel.',
+    )
+    dtb: FilePath | None = Field(
+        default=None,
+        description='Path to the guest device tree binary on the host system.',
+    )
+
+
+class OSContainerBootInfo(_BaseOSInfo):
+    '''Model representing a container boot setup.'''
+    variant: Literal['container']
+    init: FilePath = Field(
+        description='Absolute path within the container to the init process for the container.',
+    )
+    initargs: Sequence[str] = Field(
+        default_factory=list,
+        description='List of arguments to pass to the init process on startup.',
+    )
+    initenv: Mapping[NonEmptyString, str | int | float] = Field(
+        default_factory=dict,
+        description='Mapping of environment variables to use when launching the init process.',
+    )
+    initdir: Annotated[str, Field(pattern=r'^/.*$')] | None = Field(
+        default=None,
+        description='Working directory in the container to start the init process in.',
+    )
+    inituser: NonEmptyString | Annotated[int, Field(ge=0)] | None = Field(
+        default=None,
+        description='User to start the init process as, either specified as a user name or a numeric UID.',
+    )
+    initgroup: NonEmptyString | Annotated[int, Field(ge=0)] | None = Field(
+        default=None,
+        description='Group to start the init process as, either specified as a group name or a numeric GID.',
+    )
+    idmap: OSContainerIDMapInfo | None = Field(
+        default=None,
+        description='Configuration for mapping of host UIDs and GIDs to container UIDs and GIDs.',
+    )
+
+
+class OSTestBootInfo(Model):
+    '''Model representing boot configuration for a 'test' type domain.'''
+    variant: Literal['test']
+    arch: NonEmptyString = Field(
+        description='The CPU architecture to use for this domain. Accepted values vary based on the domain type.',
+    )
+
+
+class ClockTimerInfo(Model):
     '''Model representing a timer configuration within the clock configurationf or a domain.
 
        All properties correspond directly to the attributes of the same
        name for the resultant <timer /> element.'''
-    name: Literal['platform', 'hpet', 'kvmclock', 'pit', 'rtc', 'tsc', 'hypervclock', 'armvtimer']
-    track: Literal['boot', 'guest', 'wall', 'realtime'] | None = Field(default=None)
-    tickpolicy: Literal['delay', 'catchup', 'merge', 'discard'] | None = Field(default=None)
-    present: YES_NO | None = Field(default=None)
+    name: Literal['platform', 'hpet', 'kvmclock', 'pit', 'rtc', 'tsc', 'hypervclock', 'armvtimer'] = Field(
+        description='The name of the timer to configure. Supported timers depend on the hypervisor, ' +
+                    'the domain type, and the domain CPU architecture.',
+    )
+    track: Literal['boot', 'guest', 'wall', 'realtime'] | None = Field(
+        default=None,
+        description='Indicates what time the timer should track.',
+    )
+    tickpolicy: Literal['delay', 'catchup', 'merge', 'discard'] | None = Field(
+        default=None,
+        description='Indicates how the timer should handle missed ticks.',
+    )
+    present: V_YesNo | None = Field(
+        default=None,
+        description='Whether or not the timer should be enabled. If not specified, the timer is implicitly enabled.',
+    )
 
 
-class ClockInfo(BaseModel):
-    '''Model representing clock configuration for a domain.
-
-       Other than the `timers` property, all properties correspond
-       directly to the properties of the same name on the <clock>
-       element in the domain config.
-
-       The `timers` property is a sequence of ClockTimerInfo instances
-       to add to the clock element.'''
-    offset: Literal['utc', 'localtime', 'timezone', 'variable', 'absolute'] = Field(default='utc')
-    tz: str | None = Field(default=None, min_length=1)
-    basis: Literal['utc', 'localtime'] | None = Field(default=None)
-    adjustment: int | None = Field(default=None)
-    start: int | None = Field(default=None)
-    timers: Sequence[ClockTimerInfo] = Field(default_factory=list)
-
-    @model_validator(mode='after')
-    def check_required_attrs(self: Self) -> Self:
-        match self.offset:
-            case 'timezone':
-                if self.tz is None:
-                    raise ValueError('A timezone must be specified using the "tz" property if offset is set to "timezone".')
-            case 'variable':
-                if self.basis is None:
-                    raise ValueError('The "basis" property must be specified if offset is set to "variable".')
-
-                if self.adjustment is None:
-                    raise ValueError('The "adjustment" property must be specified if offset is set to "variable".')
-            case 'absolute':
-                if self.start is None:
-                    raise ValueError('The "start" property must be specified if offset is set to "absolute".')
-
-        return self
+class _BaseClock(Model):
+    '''Shared fields for all clock configurations.'''
+    timers: Sequence[ClockTimerInfo] = Field(
+        default_factory=list,
+        description='A list of clock timer configuration items.',
+    )
 
 
-class FeaturesHyperVSpinlocks(BaseModel):
+class ClockUTC(_BaseClock):
+    '''Model representing a clock configured to track UTC.'''
+    offset: Literal['utc']
+
+
+class ClockLocal(_BaseClock):
+    '''Model representing a clock configured to track local time.'''
+    offset: Literal['localtime']
+
+
+class ClockTimezone(_BaseClock):
+    '''Model representing a clock configured to track a specific timezone.'''
+    offset: Literal['timezone']
+    tz: NonEmptyString = Field(
+        description='The name of the timezone to track. The value should match an entry in the host system’s timezone database.',
+    )
+
+
+class ClockVariable(_BaseClock):
+    '''Model representing a clock configured to track time based on what the guest sets.'''
+    offset: Literal['variable']
+    basis: Literal['utc', 'localtime'] = Field(
+        default='utc',
+        description='Controls what offset to base the variable time tracking on.',
+    )
+    adjustment: int = Field(
+        default=0,
+        description='The number of seconds of offset from the time specified by the basis property.',
+    )
+
+
+class ClockAbsolute(_BaseClock):
+    '''Model representing a clock configured to always have the same time at guest startup.'''
+    offset: Literal['absolute']
+    start: V_Timestamp = Field(
+        description='An timestamp representing the exact time the clock should start at on each guest boot.',
+    )
+
+
+class FeaturesHyperVSpinlocks(Model):
     '''Model representing Hyper-V spinlock config for domain features.
 
        The `state` and `retries` properties correspond to the attributes
        of the same name on the <spinlocks /> element.'''
-    state: ON_OFF
-    retries: int | None = Field(default=None, ge=4096)
+    state: V_OnOff = Field(
+        description='Whether Hyper-V spinlocks should be on or off.',
+    )
+    retries: int | None = Field(
+        default=None,
+        ge=4096,
+        description='How many retries to use with Hyper-V spinlocks. If not specified, the hypervisor default will be used.',
+    )
 
 
-class FeaturesHyperVSTimer(BaseModel):
+class FeaturesHyperVSTimer(Model):
     '''Model representing Hyper-V stimer config for domain features.
 
        The `state` and `direct` properties correspond to the attributes
        of the same name on the <stimer /> element.'''
-    state: ON_OFF
-    direct: ON_OFF | None = Field(default=None)
+    state: V_OnOff = Field(
+        description='Whether or not the Hyper-V stimer feature should be enabled.',
+    )
+    direct: V_OnOff | None = Field(
+        default=None,
+        description='Whether direct mode should be enabled for the Hyper-V stimer feature or not.',
+    )
 
 
-class FeaturesHyperVVendorID(BaseModel):
+class FeaturesHyperVVendorID(Model):
     '''Model representing Hyper-V vendor_id config for domain features.
 
        The `state` and `value` properties correspond to the attributes
        of the same name on the <vendor_id /> element.'''
-    state: ON_OFF
-    value: str | None = Field(default=None, min_length=1, max_length=12)
+    state: V_OnOff = Field(
+        description='Whether or not the Hyper-V vendor ID should be exposed to the guest.',
+    )
+    value: Annotated[str, Field(min_length=1, max_length=12)] | None = Field(
+        default=None,
+        description='The vendor ID that should be exposed to the guest.',
+    )
 
 
-class FeaturesHyperVInfo(BaseModel):
+class FeaturesHyperVInfo(Model):
     '''Model representing Hyper-V features configuration for a domain.
 
        `mode` corresponds to the attribute of the same name for the
@@ -539,22 +552,74 @@ class FeaturesHyperVInfo(BaseModel):
 
        Other properties correspond to the elements of the same name
        that would be put in the <hyperv> element in the config.'''
-    mode: Literal['passthrough', 'custom'] = Field(default='passthrough')
-    avic: ON_OFF | None = Field(default=None)
-    evmcs: ON_OFF | None = Field(default=None)
-    frequencies: ON_OFF | None = Field(default=None)
-    ipi: ON_OFF | None = Field(default=None)
-    reenlightenment: ON_OFF | None = Field(default=None)
-    relaxed: ON_OFF | None = Field(default=None)
-    reset: ON_OFF | None = Field(default=None)
-    runtime: ON_OFF | None = Field(default=None)
-    spinlocks: FeaturesHyperVSpinlocks | None = Field(default=None)
-    stimer: FeaturesHyperVSTimer | None = Field(default=None)
-    synic: ON_OFF | None = Field(default=None)
-    tlbflush: ON_OFF | None = Field(default=None)
-    vapic: ON_OFF | None = Field(default=None)
-    vendor_id: FeaturesHyperVVendorID | None = Field(default=None)
-    vpindex: ON_OFF | None = Field(default=None)
+    mode: Literal['passthrough', 'custom'] = Field(
+        default='passthrough',
+        description='What mode to use for handling Hyper-V features. This will be set to the ' +
+                    'correct value automatically and should not need to be specified manually.',
+    )
+    avic: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not the Hyper-V AVIC feature should be enabled. If not specified, the hypervisor default will be used.',
+    )
+    evmcs: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not the Hyper-V Enlightened VMCS feature should be enabled. ' +
+                    'If not specified, the hypervisor default will be used.',
+    )
+    frequencies: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not the Hyper-V frequency MSRs should be enabled. If not specified, the hypervisor default will be used.',
+    )
+    ipi: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not the Hyper-V PV IPI feature should be enabled. If not specified, the hypervisor default will be used.',
+    )
+    reenlightenment: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not re-enlightenment notification on migration should be enabled. ' +
+                    'If not specified, the hypervisor default will be used.',
+    )
+    relaxed: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not Hyper-V relaxed timer constraints should be enabled. If not specified, the hypervisor default will be used.',
+    )
+    reset: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not the Hyper-V hypervisor reset feature should be enabled. If not specified, the hypervisor default will be used.',
+    )
+    runtime: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not Hyper-V runtime tracking should be enabled. If not specified, the hypervisor default will be used.',
+    )
+    spinlocks: FeaturesHyperVSpinlocks | None = Field(
+        default=None,
+        description='Configuration for the Hyper-V spinlocks feature. If not specified, hypervisor defaults will be used.',
+    )
+    stimer: FeaturesHyperVSTimer | None = Field(
+        default=None,
+        description='Configuration for the Hyper-V stimer feature. If not specified, hypervisor defaults will be used.',
+    )
+    synic: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not the Hyper-V SynIC feature should be enabled. If not specified, the hypervisor default will be used.',
+    )
+    tlbflush: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not the Hyper-V PV TLB flush feature should be enabled. If not specified, the hypervisor default will be used.',
+    )
+    vapic: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not the Hyper-V virtual APIC feature should be enabled. If not specified, the hypervisor default will be used.',
+    )
+    vendor_id: FeaturesHyperVVendorID | None = Field(
+        default=None,
+        description='Configuration for the Hyper-V vendor ID feature. If not specified, hypervisor defaults will be used.',
+    )
+    vpindex: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not the Hyper-V virtual processor index feature should be enabled. ' +
+                    'If not specified, the hypervisor default will be used.',
+    )
 
     @model_validator(mode='after')
     def fixup_mode(self: Self) -> Self:
@@ -566,13 +631,20 @@ class FeaturesHyperVInfo(BaseModel):
         return self
 
 
-class FeaturesKVMDirtyRing(BaseModel):
+class FeaturesKVMDirtyRing(Model):
     '''Model representing KVM dirty-ring config for domain features.
 
        The properties correspond to the equivalently named attributes
        on the <dirty-ring /> element.'''
-    state: ON_OFF
-    size: int | None = Field(default=None, ge=1024, le=65536)
+    state: V_OnOff = Field(
+        description='Whether the KVM dirty-ring feature should be enabled or not.',
+    )
+    size: int | None = Field(
+        default=None,
+        ge=1024,
+        le=65536,
+        description='Size of the KVM dirty ring buffer. Must be a power of two. If not specified, the hypervisor default will be used.',
+    )
 
     @field_validator('size')
     @classmethod
@@ -583,75 +655,133 @@ class FeaturesKVMDirtyRing(BaseModel):
         return v
 
 
-class FeaturesKVMInfo(BaseModel):
+class FeaturesKVMInfo(Model):
     '''Model representing KVM features configuration for a domain.
 
        The properties correspond to the equivalently named elements that
        can be found in the <kvm> element in the domain configuration.'''
-    dirty_ring: FeaturesKVMDirtyRing | None = Field(default=None)
-    hidden: ON_OFF | None = Field(default=None)
-    hint_dedicated: ON_OFF | None = Field(default=None)
-    poll_control: ON_OFF | None = Field(default=None)
-    pv_ipi: ON_OFF | None = Field(default=None)
+    dirty_ring: FeaturesKVMDirtyRing | None = Field(
+        default=None,
+        description='Configuration for the KVM dirty-ring feature. If not present, hypervisor defaults will be used.',
+    )
+    hidden: V_OnOff | None = Field(
+        default=None,
+        description='Whether to or not to hide KVM from MSR-based discovery. If not present, the hypervisor default will be used.',
+    )
+    hint_dedicated: V_OnOff | None = Field(
+        default=None,
+        description='Hint to the guest that it’s vCPUs are pinned to host CPUs. If not present, the hypervisor default will be used.',
+    )
+    poll_control: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not the KVM poll-control feature should be enabled. If not present, the hypervisor default will be used.',
+    )
+    pv_ipi: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not the KVM PV IPI feature should be enabled. If not present, the hypervisor default will be used.',
+    )
 
 
-class FeaturesXenPassthrough(BaseModel):
+class FeaturesXenPassthrough(Model):
     '''Model representing Xen passthrough config for domain features.
 
        The properties correspond to the equivalently named attributes
        on the <passthrough /> element.'''
-    state: ON_OFF
-    mode: Literal['sync_pt', 'share_pt'] | None = Field(default=None)
+    state: V_OnOff = Field(
+        description='Whether or not to enable Xen IOMMU passthrough mappings.',
+    )
+    mode: Literal['sync_pt', 'share_pt'] | None = Field(
+        default=None,
+        description='Indicates the operational mode of Xen IOMMU passthrough support. If not specified, the hypervisor default will be used.',
+    )
 
 
-class FeaturesXenInfo(BaseModel):
+class FeaturesXenInfo(Model):
     '''Model representing Xen features configuration for a domain.
 
        The properties correspond to the equivalently named elements that
        can be found in the <xen> element in the domain configuration.'''
-    e820_host: ON_OFF | None = Field(default=None)
-    passthrough: FeaturesXenPassthrough | None = Field(default=None)
+    e820_host: V_OnOff | None = Field(
+        default=None,
+        description='Whether to expose the host e820 memory mappings to a PV guest domain or not. ' +
+                    'If not specified, the hypervisor default will be used.',
+    )
+    passthrough: FeaturesXenPassthrough | None = Field(
+        default=None,
+        description='Configuration for Xen IOMMU passthrough. If not specified, the hypervisor defaults will be used.',
+    )
 
 
-class FeaturesTCGInfo(BaseModel):
+class FeaturesTCGInfo(Model):
     '''Model representing TCG features configuration for a domain.
 
        The `tb_cache` property indicates the size in mibibytes (not
        bytes or megabytes) of the TCG translation block cache.'''
-    tb_cache: int | None = Field(default=None, gt=0)
+    tb_cache: int | None = Field(
+        default=None,
+        gt=0,
+        description='THe size of the TCG translation block cache to use, specified in mibibytes. ' +
+                    'If not specified, the hypervisor default will be used.',
+    )
 
 
-class FeaturesAPICInfo(BaseModel):
+class FeaturesAPICInfo(Model):
     '''Model representing APIC features configuration for a domain.
 
        The `eoi` property corresponds to the attribute of the same name
        on the <apic /> element in the domain configuration. A value of
        None for that property indicates that an <apic /> element should
        be present, but should not have any attributes.'''
-    eoi: ON_OFF | None = Field(default=None)
+    eoi: V_OnOff | None = Field(
+        default=None,
+        description='Whether End Of Interrupt functionality should be available to the guest. If not specified, the hypervisor default will be used.',
+    )
 
 
-class FeaturesGICInfo(BaseModel):
+class FeaturesGICInfo(Model):
     '''Model representing GIC features configuration for a domain.
 
        The `version` property corresponds to the attribute of the same
        name on the <gic /> element in the domain configuration. A value
        of None for that property indicates that an <gic /> element should
        be present, but should not have any attributes.'''
-    version: Literal[2, '2', 3, '3', 'host'] | None = Field(default=None)
+    version: Literal[2, '2', 3, '3', 'host'] | None = Field(
+        default=None,
+        description='The GIC version to be used for this guest. If not specified, the hypervisor default will be used.',
+    )
 
 
-class FeaturesIOAPICInfo(BaseModel):
+class FeaturesIOAPICInfo(Model):
     '''Model representing IOAPIC features configuration for a domain.
 
        The `driver` property corresponds to the attribute of the same
        name on the <ioapic /> element in the domain configuration. A
        value of None for that property indicates that an <ioapic />
        element should be present, but should not have any attributes.'''
-    driver: Literal['kvm', 'qemu'] | None = Field(default=None)
+    driver: Literal['kvm', 'qemu'] | None = Field(
+        default=None,
+        description='Specifies the driver mode to use for the guest IO-APIC. If not specified, the hypervisor default will be used.',
+    )
 
 
-class FeaturesCapabilities(BaseModel):
+class FeaturesSMMConfig(Model):
+    '''Model representing SMM configuration for a domain.
+
+       The properties correspond to the properties of the same name on
+       the <smm /> element in the domain XML.'''
+    state: V_OnOff = Field(
+        description='Specifies whether SMM support should be enabled for the guest or not.',
+    )
+    tseg: int | None = Field(
+        default=None,
+        gt=0,
+        description='Specifies the size of the SMM extended TSEG in bytes. This should be left unspecified ' +
+                    'unless the domain has hundreds of vCPUs or a very large address space (in excess of 1 TiB). ' +
+                    'If not specified, the hypervisor default will be used.',
+    )
+
+
+class FeaturesCapabilities(Model):
     '''Model representing capabilities configuration for a domain.
 
        The `policy` property corresponds to the attribute of the same
@@ -660,83 +790,243 @@ class FeaturesCapabilities(BaseModel):
        The `modify` property is a mapping of capability names to
        capability states, with each entry corresponding to an element
        under the <capabilities> element.'''
-    policy: Literal['default', 'allow', 'deny']
-    modify: Mapping[str, str] = Field(default_factory=dict)
-
-    @field_validator('modify')
-    @classmethod
-    def check_modify(cls: type[FeaturesCapabilities], m: Mapping[str, str], info: ValidationInfo) -> Mapping[str, str]:
-        for k, v in m.items():
-            if v not in {'on', 'off'}:
-                raise ValueError(f'Value "{ v }" for key "{ k }" in property "modify" is not valid, must be "on" or "off"')
-
-        return m
+    policy: Literal['default', 'allow', 'deny'] = Field(
+        description='Specify the default policy for domain capabilities.',
+    )
+    modify: Mapping[NonEmptyString, V_OnOff] = Field(
+        default_factory=dict,
+        description='Specify individual overrides for the default policy. Keys should be capability names, values should indicate whether that ' +
+                    'capability will be enabled for the domain or not. If not specified or left empty, the default policy will be followed for ' +
+                    'all capabilities.',
+    )
 
 
-class FeaturesInfo(BaseModel):
+class FeaturesInfo(Model):
     '''Model representing the contents of the <features> element in domain configuration.
 
        The individual properties correspond to the elements of the
        equivalent name found in the <features> element in the domain
        configuration.'''
-    acpi: bool | None = Field(default=None)
-    apic: FeaturesAPICInfo | None = Field(default=None)
-    async_teardown: ON_OFF | None = Field(default=None)
-    caps: FeaturesCapabilities | None = Field(default=None)
-    gic: FeaturesGICInfo | None = Field(default=None)
-    hap: ON_OFF | None = Field(default=None)
-    htm: ON_OFF | None = Field(default=None)
-    hyperv: FeaturesHyperVInfo | None = Field(default=None)
-    kvm: FeaturesKVMInfo | None = Field(default=None)
-    pae: bool | None = Field(default=None)
-    pmu: ON_OFF | None = Field(default=None)
-    pvspinlock: ON_OFF | None = Field(default=None)
-    smm: ON_OFF | None = Field(default=None)
-    tcg: FeaturesTCGInfo | None = Field(default=None)
-    vmcoreinfo: ON_OFF | None = Field(default=None)
-    vmport: ON_OFF | None = Field(default=None)
-    xen: FeaturesXenInfo | None = Field(default=None)
+    acpi: V_OnOff | None = Field(
+        default=None,
+        description='Whether ACPI should be enabled for the domain or not. If not specified, the hypervisor default will be used.',
+    )
+    apic: FeaturesAPICInfo | None = Field(
+        default=None,
+        description='Configuration for the domain APIC. If not specified, hypervisor defaults will be used.',
+    )
+    async_teardown: V_OnOff | None = Field(
+        default=None,
+        description='Whether asynchronous teardown should be enabled for the domain or not. If not specified, the hypervisor default will be used.',
+    )
+    caps: FeaturesCapabilities | None = Field(
+        default=None,
+        description='Configuration for the domain capabilities. If not specified, hypervisor defaults will be used.',
+    )
+    gic: FeaturesGICInfo | None = Field(
+        default=None,
+        description='Configuration for the domain GIC. If not specified, hypervisor defaults will be used.',
+    )
+    hap: V_OnOff | None = Field(
+        default=None,
+        description='Whether Hardware Assisted Paging should be enabled for the domain or not. ' +
+                    'If not specified, the hypervisor default will be used.',
+    )
+    htm: V_OnOff | None = Field(
+        default=None,
+        description='Whether HTM should be enabled for the domain or not. If not specified, the hypervisor default will be used.',
+    )
+    hyperv: FeaturesHyperVInfo | None = Field(
+        default=None,
+        description='Configuration for Hyper-V features. If not specified, hypervisor defaults will be used.',
+    )
+    kvm: FeaturesKVMInfo | None = Field(
+        default=None,
+        description='Configuration for KVM features. If not specified, hypervisor defaults will be used.',
+    )
+    pae: V_OnOff | None = Field(
+        default=None,
+        description='Whether PAE should be enabled for the domain or not. If not specified, the hypervisor default will be used.',
+    )
+    pmu: V_OnOff | None = Field(
+        default=None,
+        description='Whether the guest PMU should be enabled or not. If not specified, the hypervisor default will be used.',
+    )
+    pvspinlock: V_OnOff | None = Field(
+        default=None,
+        description='Whether pvspinlocks should be enabled for the domain or not. If not specified, the hypervisor default will be used.',
+    )
+    smm: FeaturesSMMConfig | None = Field(
+        default=None,
+        description='Configuration for system management mode for the domain. If not specified, hypervisor defaults will be used.',
+    )
+    tcg: FeaturesTCGInfo | None = Field(
+        default=None,
+        description='Configuration for TCG features. If not specified, hypervisor defaults will be used.',
+    )
+    vmcoreinfo: V_OnOff | None = Field(
+        default=None,
+        description='Whether vmcoreinfo should be enabled for the domain or not. If not specified, the hypervisor default will be used.',
+    )
+    vmport: V_OnOff | None = Field(
+        default=None,
+        description='Whether VMWare IO port emulation should be enabled for the domain or not. ' +
+                    'If not specified, the hypervisor default will be used.',
+    )
+    xen: FeaturesXenInfo | None = Field(
+        default=None,
+        description='Configuration for Xen features. If not specified, hypervisor defaults will be used.',
+    )
 
 
-class ControllerDriverInfo(BaseModel):
+class ControllerDriverInfo(Model):
     '''Model representing a driver element in a controller device entry.'''
-    queues: int | None = Field(default=None, gt=0)
-    cmd_per_lun: int | None = Field(default=None, gt=0)
-    max_sectors: int | None = Field(default=None, gt=0)
+    queues: int | None = Field(
+        default=None,
+        gt=0,
+        description='Specify the number of queues that the controller should expose. For best performance, ' +
+                    'this should match the number of vcpus assigned to the domain. If not specified, the hypervisor default will be used.',
+    )
+    cmd_per_lun: int | None = Field(
+        default=None,
+        gt=0,
+        description='Specify the maximum number of commands that can be queued per LUN for host-controlled devices on a SCSI controller. ' +
+                    'If not specified, the hypervisor default will be used.',
+    )
+    max_sectors: int | None = Field(
+        default=None,
+        gt=0,
+        description='Specify the maximum amount of data that can be transferred in a single command, measured in 512-byte sectors. ' +
+                    'If not specified, the hypervisor default will be used.',
+    )
 
 
-class ControllerDevice(BaseModel):
-    '''Model representing a controller device in domain configuration.'''
-    type: str = Field(min_length=1)
-    index: int | None = Field(default=None, ge=0)
-    driver: ControllerDriverInfo | None = Field(default=None)
-    maxEventChannels: int | None = Field(default=None, gt=0)
-    maxGrantFrames: int | None = Field(default=None, gt=0)
-    model: str | None = Field(default=None, min_length=1)
-    ports: int | None = Field(default=None, gt=0)
-    vectors: int | None = Field(default=None, gt=0)
-
-    @model_validator(mode='after')
-    def check_driver(self: Self) -> Self:
-        if self.type != 'scsi' and self.driver is not None:
-            raise ValueError('Driver config is only supported for "scsi" controllers.')
-
-        return self
+class _BaseController(Model):
+    '''Base model for other controller models.'''
+    index: int | None = Field(
+        default=None,
+        ge=0,
+        description='Indicates the enumeration order for the controller. ' +
+                    'If left unspecified, the lowest unused index for the controller type will be auto-assigned.',
+    )
 
 
-class DiskVolumeSrcInfo(BaseModel):
+class SimpleController(_BaseController):
+    '''A simple controller device definition that supports no additional configuration.'''
+    type: Literal['fdc', 'sata', 'ccid']
+
+
+class XenBusController(_BaseController):
+    '''A Xen Bus controller device.'''
+    type: Literal['xenbus']
+    maxEventChannels: int | None = Field(
+        default=None,
+        gt=0,
+        description='Specifies the number of event channels the controller provides. ' +
+                    'If not specified, the hypervisor default will be used.',
+    )
+    maxGrantFrames: int | None = Field(
+        default=None,
+        gt=0,
+        description='Specifies the number of grant frames the controller provides. ' +
+                    'If not specified, the hypervisor default will be used.',
+    )
+
+
+class _ModelController(_BaseController):
+    '''Base model for controllers that support a 'model' attribute.'''
+    model: NonEmptyString | None = Field(
+        default=None,
+        description='Specifies the model of controller to use. If left unspecified, the hypervisor default will be used.',
+    )
+
+
+class IDEController(_ModelController):
+    '''An IDE controller device.'''
+    type: Literal['ide']
+
+
+class SCSIController(_ModelController):
+    '''A SCSI controller device.'''
+    type: Literal['scsi']
+    driver: ControllerDriverInfo | None = Field(
+        default=None,
+        description='Driver configuration for the SCSI controller.',
+    )
+
+
+class USBController(_ModelController):
+    '''A USB controller device.'''
+    type: Literal['usb']
+    ports: int | None = Field(
+        default=None,
+        gt=0,
+        description='Specifies the number of ports that should be available on this USB controller. ' +
+                    'If left unspecified, the hypervisor default will be used.',
+    )
+
+
+class VirtIOSerialController(_ModelController):
+    '''A VirtIO serial controller device.'''
+    type: Literal['virtio-serial']
+    ports: int | None = Field(
+        default=None,
+        gt=0,
+        description='Specifies the number of ports that should be available on this controller. ' +
+                    'If left unspecified, the hypervisor default will be used.',
+    )
+    vectors: int | None = Field(
+        default=None,
+        gt=0,
+        description='Specifies the number of vectors that should be available on this controller. ' +
+                    'If left unspecified, the hypervisor default will be used.',
+    )
+
+
+ControllerDevice = Annotated[
+    SimpleController | XenBusController | IDEController | SCSIController | USBController | VirtIOSerialController,
+    Field(
+        discriminator='type',
+    )
+]
+
+
+class DiskVolumeSrcInfo(Model):
     '''Model representing a disk device volume source.'''
-    pool: str = Field(min_length=1)
-    volume: str = Field(min_length=1)
+    pool: NonEmptyString = Field(
+        description='The name of the storage pool the volume backing the disk is in.',
+    )
+    volume: NonEmptyString = Field(
+        description='The name of the volume backing the disk.',
+    )
 
 
-class DiskTargetInfo(BaseModel):
+class DiskTargetInfo(Model):
     '''Model representing a disk device target.'''
-    dev: str = Field(min_length=1)
-    addr: PCIAddress | DriveAddress | None = Field(default=None)
-    bus: str | None = Field(default=None, min_length=1)
-    removable: ON_OFF | None = Field(default=None)
-    rotation_rate: int | None = Field(default=None, gt=0, lt=65535)
+    dev: FilePath = Field(
+        description='A device identifier indicating how the disk should enumerate in the guest.',
+    )
+    addr: PCIAddress | DriveAddress | None = Field(
+        default=None,
+        description='The exact address to use for the disk. Possible types are limited by the bus type. ' +
+                    'If this property is specified, the bus property must also be specified. If not specified, libvirt will infer a sane default.',
+    )
+    bus: NonEmptyString | None = Field(
+        default=None,
+        description='The bus type to use when exposing the disk to the guest. If not specified, libvirt will infer a sane default.',
+    )
+    removable: V_OnOff | None = Field(
+        default=None,
+        description="Whether the disk should be presented as removable or not. Only supported for bus types 'usb' and 'scsi'. " +
+                    'If not specified, the disk will be presented as non-removable if possible.',
+    )
+    rotation_rate: int | None = Field(
+        default=None,
+        gt=0,
+        lt=65535,
+        description='The rotation rate to report to the guest for the disk. Must be either 1 (which indicates non-rotational media) or a number ' +
+                    'between 1024 and 65534 inclusive. If not specified, the hypervisor default will be used.',
+    )
 
     @model_validator(mode='after')
     def check_addr(self: Self) -> Self:
@@ -745,6 +1035,7 @@ class DiskTargetInfo(BaseModel):
                 raise ValueError('Disk target address may only be specified if a target bus is specified.')
 
             joiner = '" or "'
+            valid_bus = set()
 
             match self.addr:
                 case PCIAddress():
@@ -761,63 +1052,139 @@ class DiskTargetInfo(BaseModel):
 
         return self
 
-
-class DiskDevice(BaseModel):
-    '''Model representing a disk device in domain config.'''
-    type: Literal['file', 'block', 'volume']
-    src: str | DiskVolumeSrcInfo
-    target: DiskTargetInfo
-    boot: int | None = Field(default=None, gt=0)
-    device: Literal['disk', 'floppy', 'cdrom', 'lun'] | None = Field(default=None)
-    readonly: bool = Field(default=False)
-    snapshot: Literal['internal', 'external', 'manual', 'no'] | None = Field(default=None)
-    startup: Literal['mandatory', 'requisite', 'optional'] | None = Field(default=None)
-
     @model_validator(mode='after')
-    def check_startup(self: Self) -> Self:
-        if self.startup is not None and self.type not in {'file', 'volume'}:
-            raise ValueError('Startup property is only supported for "file" or "volume" type disks.')
-
-        return self
-
-    @model_validator(mode='after')
-    def check_src(self: Self) -> Self:
-        match self.type:
-            case 'volume':
-                if not isinstance(self.src, DiskVolumeSrcInfo):
-                    raise ValueError('"src" property must be a DiskVolumeSrcInfo instance for "volume" type disk devices.')
-            case 'file' | 'block':
-                if not isinstance(self.src, str):
-                    raise ValueError(f'"src" property must be a string for "{self.type}" type disk devices.')
-
-                if len(self.src) < 1:
-                    raise ValueError('"src" property must be a non-empty string.')
-            case _:
-                raise RuntimeError
+    def check_removable(self: Self) -> Self:
+        if self.removable is not None and self.bus not in {'scsi', 'usb'}:
+            raise ValueError('"removable" property may only be specified for a bus of "scsi" or "usb".')
 
         return self
 
 
-class FilesystemDriverInfo(BaseModel):
+class _BaseDisk(Model):
+    '''Base model for disk devices.'''
+    boot: int | None = Field(
+        default=None,
+        gt=0,
+        description='The boot device index for the disk. If not specified, the disk will not be considered for booting.',
+    )
+    device: Literal['disk', 'floppy', 'cdrom', 'lun'] | None = Field(
+        default='disk',
+        description='The type of disk device to expose to the guest.',
+    )
+    readonly: V_YesNo = Field(
+        default=V_YesNo(False),
+        description='Whether the disk should be read-only.',
+    )
+    snapshot: Literal['internal', 'external', 'manual', 'no'] | None = Field(
+        default=None,
+        description='The snapshotting mode for the disk. If not specified, the hypervisor default will be used.',
+    )
+    target: DiskTargetInfo = Field(
+        description='Configuration for how the disk is presented to the guest.',
+    )
+
+
+class _DiskStartupMixin(Model):
+    '''Mixin to add startup property to a disk device model.'''
+    startup: Literal['mandatory', 'requisite', 'optional'] | None = Field(
+        default=None,
+        description='Startup handling behavior for this disk. Equivalent to the startuPolicy attribute on the <source /> element.',
+    )
+
+
+class FileDisk(_BaseDisk, _DiskStartupMixin):
+    '''A disk device backed by a disk image in a file on the host.'''
+    type: Literal['file']
+    src: FilePath = Field(
+        description='The path to the disk image to use for this disk.',
+    )
+
+
+class BlockDisk(_BaseDisk):
+    '''A simple disk device backed by a block device on the host.'''
+    type: Literal['block']
+    src: FilePath = Field(
+        description='The path to the block device to use for this disk.',
+    )
+
+
+class VolumeDisk(_BaseDisk, _DiskStartupMixin):
+    '''A disk device backed by a volume in a libvirt storage pool.'''
+    type: Literal['volume']
+    src: DiskVolumeSrcInfo = Field(
+        description='Identifies the volume to use for this disk.',
+    )
+
+
+DiskDevice = Annotated[
+    FileDisk | BlockDisk | VolumeDisk,
+    Field(
+        disciminator='type',
+    )
+]
+
+
+class FilesystemDriverInfo(Model):
     '''Model representing a filesystem device driver in domain config.'''
-    type: str = Field(min_length=1)
-    format: str | None = Field(default=None, min_length=1)
-    queues: int | None = Field(default=None, gt=0)
-    wrpolicy: str | None = Field(default=None, min_length=1)
+    type: NonEmptyString = Field(
+        description='The driver type to use. Supported values vary based on the hypervisor being used and the filesystem type.',
+    )
+    format: NonEmptyString | None = Field(
+        default=None,
+        description='The filesystem type to use. Only supported for certain driver types. Supported values depend on the driver type.',
+    )
+    queues: int | None = Field(
+        default=None,
+        gt=0,
+        description='The number of queues to provide for a virtiofs type filesystem.',
+    )
+    wrpolicy: NonEmptyString | None = Field(
+        default=None,
+        description='Specify the host-side write-caching policy for the filesystem. Only supported for some driver types.',
+    )
 
 
-class Filesystem(BaseModel):
+class Filesystem(Model):
     '''Model representing a filesystem device in domain config.'''
-    type: Literal['mount', 'template', 'file', 'block', 'ram', 'bind']
-    source: str = Field(min_length=1)
-    target: str = Field(min_length=1)
-    accessmode: Literal['passthrough', 'mapped', 'squash'] | None = Field(default=None)
-    dmode: str | None = Field(default=None, min_length=1)
-    driver: FilesystemDriverInfo | None = Field(default=None)
-    fmode: str | None = Field(default=None, min_length=1)
-    multidev: Literal['default', 'remap', 'forbid', 'warn'] | None = Field(default=None)
-    readonly: bool = Field(default=False)
-    src_type: str | None = Field(default=None, min_length=1)
+    type: Literal['mount', 'template', 'file', 'block', 'ram', 'bind'] = Field(
+        description='The type of filesystem interface to use. Supported interfaces depend on the domain type.',
+    )
+    source: NonEmptyString = Field(
+        description='Filesystem source. Exact meaning depends on the filesystem type and driver type.',
+    )
+    target: NonEmptyString = Field(
+        description='Filesystem target identifier. Meaning depends on filesystem type and driver type.',
+    )
+    accessmode: Literal['passthrough', 'mapped', 'squash'] | None = Field(
+        default=None,
+        description='How to handle permissions for the filesystem. Only supported by some driver types.',
+    )
+    dmode: FileMode | None = Field(
+        default=None,
+        description="Directory permissions to use for newly created directories with an accessmode of 'mapped'.",
+    )
+    fmode: FileMode | None = Field(
+        default=None,
+        description="File permissions to use for newly created files with an accessmode of 'mapped'.",
+    )
+    driver: FilesystemDriverInfo | None = Field(
+        default=None,
+        description='Host driver configuration for the filesystem. If not specified, hypervisor defaults will be used.',
+    )
+    multidev: Literal['default', 'remap', 'forbid', 'warn'] | None = Field(
+        default=None,
+        description='Configure handling of filesystems exposing multiple device IDs. Only supported for 9P-based filesystems on QEMU domains.',
+    )
+    readonly: V_YesNo = Field(
+        default=V_YesNo(False),
+        description='Whether the filesystem should be read-only for the guest or not.',
+    )
+    src_type: NonEmptyString | None = Field(
+        default=None,
+        description='The type of source identifier for this filesystem. Most filesystem and driver combinations only support a single source type, ' +
+                    'in which case this will be handled automatically. Users should only need to specify this manually when using specific driver ' +
+                    'types that support more than one type of source.',
+    )
 
     @model_validator(mode='after')
     def set_src_type(self: Self) -> Self:
@@ -832,153 +1199,268 @@ class Filesystem(BaseModel):
         return self
 
 
-class NetworkVPort(BaseModel):
+class NetworkVPort(Model):
     '''Model representing a virtualport element for a network interface.'''
-    type: str | None = Field(default=None, min_length=1)
-    instanceid: str | None = Field(default=None, min_length=1)
-    interfaceid: str | None = Field(default=None, min_length=1)
-    managerid: str | None = Field(default=None, min_length=1)
-    profileid: str | None = Field(default=None, min_length=1)
-    typeid: str | None = Field(default=None, min_length=1)
-    typeidversion: int | None = Field(default=None, gt=0)
+    type: NonEmptyString | None = Field(
+        default=None,
+        description='The type of virtualport to configure.',
+    )
+    instanceid: NonEmptyString | None = Field(
+        default=None,
+        description='The instance ID for the virtual port.',
+    )
+    interfaceid: NonEmptyString | None = Field(
+        default=None,
+        description='The interface ID for the virtual port.',
+    )
+    managerid: NonEmptyString | None = Field(
+        default=None,
+        description='The manager ID for the virtual port.',
+    )
+    profileid: NonEmptyString | None = Field(
+        default=None,
+        description='The profile ID for the virtual port.',
+    )
+    typeid: NonEmptyString | None = Field(
+        default=None,
+        description='The type ID for the virtual port.',
+    )
+    typeidversion: int | None = Field(
+        default=None,
+        gt=0,
+        description='The type ID version for the virtual port.',
+    )
 
 
-class NetworkIPInfo(BaseModel):
-    '''Model representing IP config for a user network driver.'''
-    address: IPv4Address | IPv6Address
-    prefix: int
-
-    @model_validator(mode='after')
-    def check_model(self: Self) -> Self:
-        match self.address:
-            case IPv4Address():
-                if self.prefix not in range(1, 32):
-                    raise ValueError('Prefix must be an integer between 1 and 31 inclusive for an IPv4 address.')
-            case IPv6Address():
-                if self.prefix not in range(1, 128):
-                    raise ValueError('Prefix must be an integer between 1 and 127 inclusive for an IPv6 address.')
-            case _:
-                raise RuntimeError
-
-        return self
+class NetworkIPv4Info(Model):
+    '''Model representing an IPv4 configuration for a user network driver.'''
+    address: IPv4Address = Field(
+        description='The IP address to associate with the interface.',
+    )
+    prefix: int = Field(
+        ge=1,
+        le=31,
+        description='The prefix length for the IP address.',
+    )
 
 
-class NetworkInterface(BaseModel):
-    '''Model representing a network interface in domain configuration.'''
-    type: Literal['network', 'bridge', 'direct', 'user']
-    src: str | None = Field(default=None, min_length=1)
-    mode: Literal['vepa', 'bridge', 'private', 'passthrough'] | None = Field(default=None)
-    target: str | None = Field(default=None, min_length=1)
-    mac: MacAddress | None = Field(default=None)
-    boot: int | None = Field(default=None, gt=0)
-    virtualport: NetworkVPort | None = Field(default=None)
-    ipv4: NetworkIPInfo | None = Field(default=None)
-    ipv6: NetworkIPInfo | None = Field(default=None)
+class NetworkIPv6Info(Model):
+    '''Model representing an IPv6 configuration for a user network driver.'''
+    address: IPv6Address = Field(
+        description='The IP address to associate with the interface.',
+    )
+    prefix: int = Field(
+        ge=1,
+        le=127,
+        description='The prefix length for the IP address.',
+    )
 
-    @model_validator(mode='after')
-    def check_mode(self: Self) -> Self:
-        if self.type == 'direct':
-            if self.mode is None:
-                raise ValueError('Mode must be specified for "direct" type network interfaces.')
-        elif self.mode is not None:
-            raise ValueError('Mode may only be specified for "direct" type network interfaces.')
 
-        return self
+class _BaseNetwork(Model):
+    '''Base model with shared properties for all network types.'''
+    boot: int | None = Field(
+        default=None,
+        gt=0,
+        description='The boot device index for the interface. If not specified, the interface will not be considered for booting.',
+    )
+    mac: MacAddress | None = Field(
+        default=None,
+        description='The MAC address to provide for the interface. If not specified, the hypervisor will assign a MAC address itself.',
+    )
+    target: NonEmptyString | None = Field(
+        default=None,
+        description='Target identifier for device enumeration. If not specified, hypervisor defaults will be used.',
+    )
+
+
+class _NetworkVPortMixin(Model):
+    '''Mixin for network types with virtualport support.'''
+    virtualport: NetworkVPort | None = Field(
+        default=None,
+        description='Virtual port configuration for the network interface.',
+    )
+
+
+class VirtualInterface(_BaseNetwork, _NetworkVPortMixin):
+    '''Model representing a network interface connected to a libvirt-managed network.'''
+    type: Literal['network']
+    src: NonEmptyString = Field(
+        description='The libvirt network name to connect the interface to.',
+    )
+
+
+class BridgeInterface(_BaseNetwork, _NetworkVPortMixin):
+    '''Model representing a network interface connected to an externally managed software bridge device.'''
+    type: Literal['bridge']
+    src: NonEmptyString = Field(
+        description='The bridge device name to connect the interface to.',
+    )
+
+
+class DirectInterface(_BaseNetwork, _NetworkVPortMixin):
+    '''Model representing a network interface bound directly to a host network interface.'''
+    type: Literal['direct']
+    src: NonEmptyString = Field(
+        description='The host device name to connect the interface to.',
+    )
+    mode: Literal['vepa', 'bridge', 'private', 'passthrough'] | None = Field(
+        default=None,
+        description='The mode to use when binding to the host device.',
+    )
+
+
+class UserInterface(_BaseNetwork):
+    '''Model representing a network interface linked to a transparent userspace proxy.'''
+    type: Literal['user']
+    ipv4: NetworkIPv4Info | None = Field(
+        default=None,
+        description='The IPv4 address to associate with the interface.',
+    )
+    ipv6: NetworkIPv6Info | None = Field(
+        default=None,
+        description='The IPv6 address to associate with the interface.',
+    )
 
     @model_validator(mode='after')
     def check_addrs(self: Self) -> Self:
-        if self.type != 'user':
-            if self.ipv4 is not None:
-                raise ValueError('IPv4 address config may only be specified for "user" type network interfaces.')
-
-            if self.ipv6 is not None:
-                raise ValueError('IPv6 address config may only be specified for "user" type network interfaces.')
+        if self.ipv4 is None and self.ipv6 is None:
+            raise ValueError('At least one address configuration must be specified for user type network interfaces.')
 
         return self
 
 
-class InputSource(BaseModel):
-    '''Model representing an input device source.'''
-    dev: str = Field(min_length=1)
-    grab: Literal['all'] | None = Field(default=None)
-    repeat: ON_OFF | None = Field(default=None)
-    grabToggle: str | None = Field(default=None, min_length=1)
+class NullInterface(_BaseNetwork):
+    '''Model representing a network interface that is not connected to anything.'''
+    type: Literal['null', None]
 
 
-class InputDevice(BaseModel):
-    '''Model representing an input device in domain configuration.'''
-    type: Literal['keyboard', 'mouse', 'tablet', 'passthrough', 'evdev']
-    bus: Literal['usb', 'ps2', 'virtio', 'xen'] | None = Field(default=None)
-    model: str | None = Field(default=None, min_length=1)
-    src: InputSource | None = Field(default=None)
+NetworkInterface = Annotated[VirtualInterface | BridgeInterface | DirectInterface | NullInterface | UserInterface, Field(discriminator='type')]
+
+
+class InputSource(Model):
+    '''Model representing an input device source for an evdev device.'''
+    dev: FilePath = Field(
+        description='The host device to connect to.',
+    )
+    grab: Literal['all'] | None = Field(
+        default=None,
+        description='Specifies input device grab handling.',
+    )
+    repeat: V_OnOff | None = Field(
+        default=None,
+        description='Specifies the auto-repeat mode.',
+    )
+    grabToggle: NonEmptyString | None = Field(
+        default=None,
+        description='The key sequence used to toggle input event grabbing.',
+    )
+
+
+class _BaseInput(Model):
+    '''Base model with shared attributes for all input devices.'''
+    bus: Literal['usb', 'ps2', 'virtio', 'xen'] | None = Field(
+        default=None,
+        description='The bus to connect the input device to in the guest. If not specified, a sane default will be used.',
+    )
+    model: NonEmptyString | None = Field(
+        default=None,
+        description='The VirtIO device model to use for a VirtIO input device.',
+    )
+
+
+class SimpleInputDevice(_BaseInput):
+    '''Represents a simple input device for the domain.'''
+    type: Literal['keyboard', 'mouse', 'tablet']
+
+
+class PassthroughInputDevice(_BaseInput):
+    '''Represents a passthrough input device for the domain.'''
+    type: Literal['passthrough']
+    src: FilePath = Field(
+        description='The host device to pass through to the guest.',
+    )
+
+
+class EvdevInputDevice(_BaseInput):
+    '''Represents an evdev input device for the domain.'''
+    type: Literal['evdev']
+    src: InputSource = Field(
+        description='Host device configuration info.',
+    )
+
+
+InputDevice = Annotated[SimpleInputDevice | PassthroughInputDevice | EvdevInputDevice, Field(discriminator='type')]
+
+
+class AddressGraphicsListener(Model):
+    '''Represents a graphics listener listening on a specific network address.'''
+    type: Literal['address']
+    listen: IPv4Address | IPv6Address = Field(
+        description='The address to listen on.',
+    )
+
+
+class NetworkGraphicsListener(Model):
+    '''Represents a graphics listener listening on a libvirt-managed network.'''
+    type: Literal['network']
+    listen: NonEmptyString = Field(
+        description='The libvirt network to listen on.',
+    )
+
+
+class SocketGraphicsListener(Model):
+    '''Represents a grpahics listener listening on a UNIX domain socket on the host.'''
+    type: Literal['socket']
+    listen: FilePath = Field(
+        description='The socket to listen on.',
+    )
+
+
+class NullGraphicsListener(Model):
+    '''Represents a graphics listener that is not connected to anything.'''
+    type: Literal['none']
+
+
+GraphicsListener = Annotated[AddressGraphicsListener | NetworkGraphicsListener | SocketGraphicsListener | NullGraphicsListener, Field(
+    discriminator='type',
+)]
+
+
+class _RemoteGraphics(Model):
+    '''Base model for graphics output interfaces that utilizes a remote connection.'''
+    listeners: Sequence[GraphicsListener] = Field(
+        default_factory=list,
+        description='A list of listeners for the device.',
+    )
+    port: NetPort | None = Field(
+        default=None,
+        description="The port to listen on. If both this and 'autoport' are not specified, a hypervisor-specific default will be used.",
+    )
+    autoport: V_YesNo | None = Field(
+        default=None,
+        description="Whether to auto-assign a port for the device or not. Mutually exclusive with the 'port' property.",
+    )
+    passwd: str | None = Field(
+        default=None,
+        description='Specifies a password for remote users to connect to the graphics device.',
+    )
+    passwdValidTo: V_Timestamp | None = Field(
+        default=None,
+        description='Specifies an expiration date and time for the password. Only supported if a password is specified. ' +
+                    'If specified as a string, this should be an ISO 8601 compliant timestamp. If no timezone is specified, ' +
+                    'it will be assumed to have a timezone of UTC. If only a date is specified, the time will be set to midnight of that day.',
+    )
+    connected: Literal['keep', 'disconnect', 'fail'] | None = Field(
+        default=None,
+        description='Specifies how to handle connected users when the password is changed or expires. Only supported if a password is specified.',
+    )
 
     @model_validator(mode='after')
-    def check_src(self: Self) -> Self:
-        if self.type in {'passthrough', 'evdev'}:
-            if self.src is None:
-                raise ValueError(f'Input source must be specified for type "{ self.type }".')
-        elif self.src is not None:
-            raise ValueError(f'Input source may not be specified for type "{ self.type }".')
+    def check_port(self: Self) -> Self:
+        if self.port is not None and self.autoport:
+            raise ValueError('If autoport is enabled, a port may not be specified.')
 
         return self
-
-
-class GraphicsListener(BaseModel):
-    '''Model for listener entries in graphics elements.'''
-    type: Literal['address', 'network', 'socket', 'none']
-    address: IPv4Address | IPv6Address | None = Field(default=None)
-    network: str | None = Field(default=None, min_length=1)
-    socket: str | None = Field(default=None, min_length=1)
-
-    @model_validator(mode='after')
-    def check_model(self: Self) -> Self:
-        match self.type:
-            case 'address':
-                none_props: tuple[str, ...] = ('network', 'socket')
-
-                if self.address is None:
-                    raise ValueError('"address" property must be specified for a listener of type "address".')
-            case 'network':
-                none_props = ('address', 'socket')
-
-                if self.network is None:
-                    raise ValueError('"network" property must be specified for a listener of type "network".')
-            case 'socket':
-                none_props = ('address', 'network')
-
-                if self.socket is None:
-                    raise ValueError('"socket" property must be specified for a listener of type "socket".')
-            case 'none':
-                none_props = ('address', 'network', 'socket')
-            case _:
-                raise RuntimeError
-
-        for attr in none_props:
-            if getattr(self, attr) is not None:
-                raise ValueError(f'Property "{ attr }" must be None for a type of "{ self.type }".')
-
-        return self
-
-
-class GraphicsDevice(BaseModel):
-    '''Model representing a graphics output interface in domain configuration.'''
-    type: Literal['vnc', 'spice', 'rdp']
-    listeners: Sequence[GraphicsListener] = Field(default_factory=list)
-    port: int | None = Field(default=None, gt=0, lt=65536)
-    tlsPort: int | None = Field(default=None, gt=0, lt=65536)
-    autoport: YES_NO | None = Field(default=None)
-    socket: str | None = Field(default=None, min_length=1)
-    passwd: str | None = Field(default=None)
-    passwdValidTo: str | None = Field(default=None, min_length=1)
-    keymap: str | None = Field(default=None, min_length=1)
-    connected: Literal['keep', 'disconnect', 'fail'] | None = Field(default=None)
-    sharePolicy: Literal['allow-exclusive', 'force-shared', 'ignore'] | None = Field(default=None)
-    powerControl: YES_NO | None = Field(default=None)
-    websocket: int | None = Field(default=None, ge=-1, lt=65536)
-    defaultMode: Literal['secure', 'insecure', 'any'] | None = Field(default=None)
-    channels: Mapping[str, Literal['secure', 'insecure']] = Field(default_factory=dict)
-    multiUser: YES_NO | None = Field(default=None)
-    replaceUser: YES_NO | None = Field(default=None)
 
     @model_validator(mode='after')
     def check_passwd_valid(self: Self) -> Self:
@@ -994,28 +1476,113 @@ class GraphicsDevice(BaseModel):
 
         return self
 
+
+class _KeymapGraphicsMixin(Model):
+    '''Base model for graphics devices that allow specifying a keymap.'''
+    keymap: NonEmptyString | None = Field(
+        default=None,
+        description='Specifies the keymap to use for VNC connections. If not specified, the hypervisor default will be used.',
+    )
+
+
+class VNCGraphics(_RemoteGraphics, _KeymapGraphicsMixin):
+    '''A VNC connected graphics output device.'''
+    type: Literal['vnc']
+    socket: FilePath | None = Field(
+        default=None,
+        description='Path to a local UNIX socket to listen on instead of listening on a netwokr port.',
+    )
+    websocket: int | None = Field(
+        default=None,
+        ge=-1,
+        lt=65536,
+        description='Port number to use for VNC WebSocket connections. A value of -1 indicates automatic assignment.',
+    )
+    sharePolicy: Literal['allow-exclusive', 'force-shared', 'ignore'] | None = Field(
+        default=None,
+        description='Specifies the policy for handling of shared-mode connections. If not specified, the hypervisor default will be used.',
+    )
+    powerControl: V_YesNo | None = Field(
+        default=None,
+        description='Enables or disables power control features for the VNC client.',
+    )
+
+
+class SPICEGraphics(_RemoteGraphics, _KeymapGraphicsMixin):
+    '''A SPICE connected graphics output device.'''
+    type: Literal['spice']
+    tlsPort: int | None = Field(
+        default=None,
+        gt=0,
+        lt=65536,
+        description='Port number to listen on for TLS connections. If not specified, TLS connections will not be enabled.',
+    )
+    defaultMode: Literal['secure', 'insecure', 'any'] | None = Field(
+        default=None,
+        description='The default channel security policy. If not specified, the hypervisor default will be used.',
+    )
+    channels: Mapping[str, Literal['secure', 'insecure']] = Field(
+        default_factory=dict,
+        description='Overrides for the defaault channel policy. Keys are channel names, ' +
+                    'while each value is the security policy for the associated channel.',
+    )
+
+
+class RDPGraphics(_RemoteGraphics):
+    '''An RDP connected graphics output device.'''
+    type: Literal['rdp']
+    multiUser: V_YesNo | None = Field(
+        default=None,
+        description='Whether or not to allow multiple concurrent connections.'
+    )
+    replaceUser: V_YesNo | None = Field(
+        default=None,
+        description='Whether or not new connections should replace existing ones in single-connection mode. ' +
+                    "May only be specified if 'mutliUser' is explicitly disabled.",
+    )
+
     @model_validator(mode='after')
     def check_user(self: Self) -> Self:
-        if self.multiUser is not None:
-            if self.type != 'rdp':
-                raise ValueError('"multiUser" property is only supported for "rdp" type graphics devices.')
-        else:
-            if self.replaceUser is not None:
-                raise ValueError('"replaceUser" property is only supported if the "multiUser" property is also specified.')
+        if self.replaceUser is not None:
+            if self.multiUser is None or self.multiUser:
+                raise ValueError('The "replaceUser" property is only supported if "multiUser" mode is explicitly disabled .')
 
         return self
 
 
-class VideoDevice(BaseModel):
+GraphicsDevice = Annotated[VNCGraphics | SPICEGraphics | RDPGraphics, Field(discriminator='type')]
+
+
+class VideoDevice(Model):
     '''Model representing a GPU device in domain configuration.'''
-    type: Literal['vga', 'cirrus', 'vmvga', 'xen', 'vbox', 'virtio', 'qxl', 'gop', 'bochs', 'ramfb', 'none']
-    vram: int | None = Field(default=None, ge=1024)
-    heads: int | None = Field(default=None, gt=0)
-    blob: ON_OFF | None = Field(default=None)
+    type: Literal['vga', 'cirrus', 'vmvga', 'xen', 'vbox', 'virtio', 'qxl', 'gop', 'bochs', 'ramfb', 'none'] = Field(
+        description="The type of GPU. The special value 'none' can be used to ensure that no GPU is connected even if the " +
+                    'domain would have one by default. Most domain types only support a subset of the listed types.',
+    )
+    vram: int | None = Field(
+        default=None,
+        ge=16,
+        description='The amount of video RAM for the GPU, measured in kibibytes. Must be a power of 2. 16 KiB is enough for all standard VGA, ' +
+                    'VESA, and Video7 text modes. 8 MiB is sufficient for almost all commonly used video output modes up to and including ' +
+                    '1080p with 24-bit color. If not specified, the hypervisor default will be used, which should be sufficient for ' +
+                    'almost any usage that does not involve ultra-high resolution or complex rendering requirements. Only supported ' +
+                    'for some domain types.',
+    )
+    heads: int | None = Field(
+        default=None,
+        gt=0,
+        description='The number of display outputs. Only supported for some GPU and hypervisor types. ' +
+                    'If not specified, a single display output will be provided.',
+    )
+    blob: V_OnOff | None = Field(
+        default=None,
+        description='Whether or not blob resources should be enabled for a VirtIO GPU. Only supported for VirtIO GPUs. ' +
+                    'If not specified, the hypervisor default will be used.'
+    )
 
     @model_validator(mode='after')
     def check_vram(self: Self) -> Self:
-        if self.vram is not None and (self.vram & (self.vram-1) != 0):
+        if self.vram is not None and (self.vram & (self.vram - 1) != 0):
             raise ValueError('VRAM amount must be a power of 2')
 
         return self
@@ -1028,202 +1595,326 @@ class VideoDevice(BaseModel):
         return self
 
 
-class CharDevSource(BaseModel):
-    '''Model representing a character device source.'''
-    path: str | None = Field(default=None, min_length=1)
-    channel: str | None = Field(default=None, min_length=1)
-    mode: Literal['bind', 'connect'] | None = Field(default=None)
-    host: str | None = Field(default=None, min_length=1)
-    service: int | None = Field(default=None, gt=0, lt=65536)
-    tls: YES_NO | None = Field(default=None)
-
-    @model_validator(mode='after')
-    def check_model(self: Self) -> Self:
-        return self._check_attrs()
-
-    def _check_attrs(self: Self) -> Self:
-        if self.path is None and self.channel is None and self.host is None:
-            raise ValueError('Must specify at least one of "path", "channel", or "host".')
-
-        if len({self.path, self.channel, self.host} - {None}) > 1:
-            raise ValueError('Only one of "path", "channel", or "host" may be specified.')
-
-        if self.host is not None:
-            if self.service is None:
-                raise ValueError('"service" must be specified if "host" is specified.')
-
-            if self.mode is None:
-                raise ValueError('"mode" must be specified if "host" is specified.')
-        else:
-            if self.service is not None:
-                raise ValueError('"service" may only be specified if "host" is specified.')
-
-            if self.tls is not None:
-                raise ValueError('"tls" may only be specified if "host" is specified.')
-
-        if self.host is None and self.path is None and self.mode is not None:
-            raise ValueError('"mode" may only be specified if "path" or "host" is specified.')
-
-        return self
+class CharDevSimpleSource(Model):
+    '''Character device source that only needs a type.'''
+    type: Literal['stdio', 'vc', 'null', None]
 
 
-class CharDevTarget(BaseModel):
-    '''Model representing a character device target.'''
-    port: int | None = Field(default=None, ge=0, lt=65536)
-    address: IPv4Address | IPv6Address | None = Field(default=None)
-    type: str | None = Field(default=None, min_length=1)
-    name: str | None = Field(default=None, min_length=1)
-    state: str | None = Field(default=None, min_length=1)
-
-    @model_validator(mode='after')
-    def check_model(self: Self) -> Self:
-        match self:
-            case CharDevTarget(port=None, address=None, name=None):
-                raise ValueError('One of "port", "address", or "name" must be specified.')
-
-        bad_attrs = set()
-
-        if self.address is not None:
-            if self.type != 'guestfwd':
-                raise ValueError('Type must be "guestfwd" if an address is specified.')
-
-            if self.port is None:
-                raise ValueError('"port" must be specified if an address is specified.')
-            elif self.port not in range(1, 65536):
-                raise ValueError('"port" must be between 1 and 65535 inclusive if an address is specified.')
-
-            key_attr = 'address'
-            bad_attrs = {
-                'name',
-                'state',
-            }
-        elif self.port is not None:
-            key_attr = 'port'
-            bad_attrs = {
-                'name',
-                'state',
-            }
-        elif self.name is not None:
-            key_attr = 'name'
-            bad_attrs = {
-                'port',
-                'address',
-            }
-
-        for attr in bad_attrs:
-            if getattr(self, attr, None) is not None:
-                raise ValueError(f'"{attr}" may not be specified if "{key_attr}" is specified.')
-
-        return self
+class CharDevPathSource(Model):
+    '''Character device soruce connected to a specific path.'''
+    type: Literal['file', 'dev', 'pipe', 'nmdm']
+    path: FilePath = Field(
+        min_length=1,
+        description='The path to use for the device source.',
+    )
 
 
-class CharDevLog(BaseModel):
+class CharDevPTYSource(Model):
+    '''Character device source connected to a pseudoterminal.'''
+    type: Literal['pty']
+    path: FilePath | None = Field(
+        default=None,
+        description='The pseudoterminal to connect to. If left empty, one will be auto-assigned on domain startup. ' +
+                    'Most users should leave this empty.',
+    )
+
+
+class CharDevSocketSource(Model):
+    '''Character device source connected to a UNIX socket.'''
+    type: Literal['unix']
+    path: FilePath = Field(
+        description='The path to the socket to use.',
+    )
+    mode: Literal['connect', 'bind'] = Field(
+        description="The mode to use. 'connect' will connect to the socket as a client, while 'bind' will listen on the socket.",
+    )
+
+
+class CharDevTCPSource(Model):
+    '''Character device source connected to a TCP client or server.'''
+    type: Literal['tcp']
+    mode: Literal['connect', 'bind'] = Field(
+        description="The mode to use. 'connect' will connect to a remote host, while 'bind' will listen on a local socket.",
+    )
+    host: Hostname | IPv4Address | IPv6Address = Field(
+        description='The hostname or IP address to connect to or listen on.',
+    )
+    service: NetPort = Field(
+        description='The port number to connect to or listen on.',
+    )
+    tls: V_YesNo | None = Field(
+        default=None,
+        description='Whether or not to enable TLS. Only supported by some hypervisors. If not specified, TLS will not be enabled.',
+    )
+
+
+class CharDevChannelSource(Model):
+    '''Character device source connected to a SPICE channel.'''
+    type: Literal['spiceport']
+    channel: NonEmptyString = Field(
+        description='The name of the SPICE channel to use.',
+    )
+
+
+CharDevSource = Annotated[
+    CharDevSimpleSource |
+    CharDevPathSource |
+    CharDevPTYSource |
+    CharDevSocketSource |
+    CharDevTCPSource |
+    CharDevChannelSource,
+    Field(
+        discriminator='type',
+    )
+]
+
+
+class _CharDevTgtPort(Model):
+    port: int = Field(
+        ge=0,
+        description='The port this character device corresponds to.',
+    )
+
+
+class ParallelDevTarget(_CharDevTgtPort):
+    '''A character device target for a parallel port.'''
+    category: Literal['parallel']
+
+
+class SerialDevTarget(_CharDevTgtPort):
+    '''A character device target for a serial port.'''
+    category: Literal['serial']
+    type: NonEmptyString | None = Field(
+        default=None,
+        description='The type of serial port to provide. If not specified, the hypervisor will infer a sane value.',
+    )
+
+
+class ConsoleDevTarget(_CharDevTgtPort):
+    '''A character device target for a console.'''
+    category: Literal['console']
+    type: Literal['serial', 'virtio', 'xen', 'lxc', 'openvz', 'sclp', 'sclplm'] = Field(
+        description='The type of console to provide.',
+    )
+
+
+class _ChannelDevTarget(Model):
+    category: Literal['channel']
+
+
+class NetChannelDevTarget(_ChannelDevTarget):
+    '''A character device target for a network channel.'''
+    type: Literal['guestfwd']
+    address: IPv4Address | IPv6Address = Field(
+        description='The IP address for the channel.',
+    )
+    port: NetPort = Field(
+        description='The TCP port to use for the channel.',
+    )
+
+
+class _NamedChannelDevTarget(_ChannelDevTarget):
+    name: NonEmptyString = Field(
+        description='The name to associate with the channel.',
+    )
+
+
+class VirtIOChannelDevTarget(_NamedChannelDevTarget):
+    '''A character device target for a VirtIO channel.'''
+    type: Literal['virtio']
+
+
+class XenChannelDevTarget(_NamedChannelDevTarget):
+    '''A character device target for a Xen channel.'''
+    type: Literal['xen']
+
+
+ChannelDevTarget = Annotated[NetChannelDevTarget | VirtIOChannelDevTarget | XenChannelDevTarget, Field(discriminator='type')]
+CharDevTarget = Annotated[ParallelDevTarget | SerialDevTarget | ConsoleDevTarget | ChannelDevTarget, Field(discriminator='category')]
+
+
+class CharDevLog(Model):
     '''Model representing log config for a character device.'''
-    file: str = Field(min_length=1)
-    append: ON_OFF | None = Field(default=None)
+    file: FilePath = Field(min_length=1)
+    append: V_OnOff | None = Field(default=None)
 
 
-class CharacterDevice(BaseModel):
+class CharacterDevice(Model):
     '''Model representing a character device in domain configuration.'''
-    category: Literal['parallel', 'serial', 'console', 'channel']
-    type: CHARDEV_SRC_TYPE
-    target: CharDevTarget
-    src: CharDevSource | None = Field(default=None)
-    log: CharDevLog | None = Field(default=None)
+    target: CharDevTarget = Field(
+        description='The target for the character device.',
+    )
+    src: CharDevSource = Field(
+        default_factory=lambda: CharDevPTYSource(type='pty', path=None),
+        description='The source for the character device. If not specified, an auto-assigned PTY source will be used.',
+    )
+    log: CharDevLog | None = Field(
+        default=None,
+        description='Logging configuration for the character device. If not specified, no logging will be configured.',
+    )
 
-    @model_validator(mode='after')
-    def check_source(self: Self) -> Self:
-        _check_char_dev_src(src_type=self.type, src=self.src)
 
-        return self
-
-
-class WatchdogDevice(BaseModel):
+class WatchdogDevice(Model):
     '''Model representing a watchdog device in domain configuration.'''
-    model: str = Field(min_length=1)
-    action: Literal['reset', 'shutdown', 'poweroff', 'pause', 'none', 'dump', 'inject-nmi'] | None = Field(default=None)
+    model: NonEmptyString = Field(
+        description='The model of watchdog device to provide. Accepted values are hypervisor-dependent.',
+    )
+    action: Literal['reset', 'shutdown', 'poweroff', 'pause', 'none', 'dump', 'inject-nmi'] | None = Field(
+        default=None,
+        description='The action to take when the watchdog timer expires. If not specified, the hypervisor default will be used.',
+    )
 
 
-class RNGBackend(CharDevSource):
-    '''Model representing a backend for an RNG device in domain configuration.'''
-    model: Literal['random', 'builtin', 'egd'] = Field(default='builtin')
-    type: CHARDEV_SRC_TYPE | None = Field(default=None)
-
-    @model_validator(mode='after')
-    def check_model(self: Self) -> Self:
-        match self:
-            case RNGBackend(model='builtin'):
-                return self
-            case RNGBackend(model='random'):
-                self._check_attrs()
-
-                _check_char_dev_src(src_type='dev', src=self)
-
-                return self
-            case RNGBackend(model='egd'):
-                if self.type is None:
-                    raise ValueError('Type must be specified for model "egd".')
-
-                self._check_attrs()
-
-                _check_char_dev_src(src_type=self.type, src=self)
-
-                return self
-            case _:
-                raise RuntimeError
+class RNGBuiltinBackend(Model):
+    '''Builtin backend for RNG devices.'''
+    model: Literal['builtin']
 
 
-class RNGDevice(BaseModel):
+class RNGRandomBackend(Model):
+    '''Backend for RNG devices that connects to a local RNG device.'''
+    model: Literal['random']
+    path: FilePath = Field(
+        description='The path to the RNG device to use.',
+    )
+
+
+class RNGEGDSocketBackend(CharDevSocketSource):
+    '''RNG backend that connects to EGD over a UNIX socket.'''
+    model: Literal['egd']
+
+
+class RNGEGDTCPBackend(CharDevTCPSource):
+    '''RNG backend that connects to EGD over a TCP socket.'''
+    model: Literal['egd']
+
+
+RNGEGDBackend = Annotated[RNGEGDSocketBackend | RNGEGDTCPBackend, Field(discriminator='type')]
+RNGBackend = Annotated[RNGBuiltinBackend | RNGRandomBackend | RNGEGDBackend, Field(discriminator='model')]
+
+
+class RNGDevice(Model):
     '''Model representing an RNG device in domain configuration.'''
-    model: str = Field(min_length=1)
-    rate: DataRate | None = Field(default=None)
-    backend: RNGBackend = Field(default_factory=RNGBackend)
+    model: NonEmptyString = Field(
+        description='The model of RNG device to provide. Valid models depend on the underlying hypervisor.',
+    )
+    rate: DataRate | None = Field(
+        default=None,
+        description='Rate limit for reading data from the RNG device. If not specified, reading will not be rate limited.',
+    )
+    backend: RNGBackend = Field(
+        default_factory=lambda: RNGBuiltinBackend(model='builtin'),
+        description='The backend for the RNG device on the host. If not specified, the builtin backend will be used.',
+    )
 
 
-class TPMDevice(BaseModel):
-    '''Model representing a TPM device in domain configuration.'''
-    type: Literal['passthrough', 'emulator']
-    model: Literal['tpm-tis', 'tpm-crb', 'tpm-spapr', 'tpm-spapr-proxy'] | None = Field(default=None)
-    dev: str | None = Field(default=None, min_length=1)
-    encryption: str | None = Field(default=None, min_length=1)
-    version: Literal['1.2', '2.0'] | None = Field(default=None)
-    persistent_state: YES_NO | None = Field(default=None)
-    active_pcr_banks: Sequence[str] = Field(default_factory=list)
+class _BaseTPM(Model):
+    model: Literal['tpm-tis', 'tpm-crb', 'tpm-spapr', 'tpm-spapr-proxy'] | None = Field(
+        default=None,
+        description='The interface provided by the TPM device. If not specified, libvirt will infer a reasonable value ' +
+                    'based on the domain configuration.',
+    )
+
+
+class PassthroughTPM(_BaseTPM):
+    '''A TPM device that exposes a host TPM device to the guest.'''
+    type: Literal['passthrough']
+    dev: FilePath = Field(
+        description='The path to the host device to pass through.',
+    )
+
+
+class EmulatedTPM(_BaseTPM):
+    '''A TPM device provided by an emulator running on the host.'''
+    type: Literal['emulator']
+    encryption: UUID | None = Field(
+        default=None,
+        description='UUID of the libvirt secret containing the passphrase used to encrypt the TPM state. ' +
+                    'If not specified, the TPM state will be stored unencrypted.',
+    )
+    version: Literal['1.2', '2.0'] | None = Field(
+        default=None,
+        description='The version of the TPM device. If not specified, libvirt will infer a sane default based on other parameters.',
+    )
+    persistent_state: V_YesNo = Field(
+        default=False,
+        description='Whether the TPM state should be kept or not when a transient domain is powered off.',
+    )
+    active_pcr_banks: Sequence[Annotated[str, Field(min_length=1)]] = Field(
+        default_factory=list,
+        description='A list of PCR banks to activate on VM startup. If not specified, active PCR banks will not be modified on startup. ' +
+                    'Duplicate entries in this list will be removed automatically.',
+    )
 
     @model_validator(mode='after')
-    def check_state(self: Self) -> Self:
-        match self.type:
-            case 'passthrough':
-                if self.dev is None:
-                    raise ValueError('Property "dev" must be specified for type "passthrough".')
-            case 'emulator':
-                pass
-            case _:
-                raise RuntimeError
-
+    def dedup_active_pcr_banks(self: Self) -> Self:
+        self.active_pcr_banks = list(set(self.active_pcr_banks))
         return self
 
 
-class SimpleDevice(BaseModel):
+TPMDevice = Annotated[PassthroughTPM | EmulatedTPM, Field(discriminator='type')]
+
+
+class SimpleDevice(Model):
     '''Model reprsenting simple devices that only support a model attribute.'''
-    model: str = Field(min_length=1)
+    model: NonEmptyString = Field(
+        description='The model of device to provide. Accepted values vary by hypervisor and domain type.',
+    )
 
 
-class Devices(BaseModel):
+class Devices(Model):
     '''Model representing device configuration for a domain.'''
-    controllers: Sequence[ControllerDevice] = Field(default_factory=list)
-    disks: Sequence[DiskDevice] = Field(default_factory=list)
-    fs: Sequence[Filesystem] = Field(default_factory=list)
-    net: Sequence[NetworkInterface] = Field(default_factory=list)
-    input: Sequence[InputDevice] = Field(default_factory=list)
-    graphics: Sequence[GraphicsDevice] = Field(default_factory=list)
-    video: Sequence[VideoDevice] = Field(default_factory=list)
-    chardev: Sequence[CharacterDevice] = Field(default_factory=list)
-    watchdog: Sequence[WatchdogDevice] = Field(default_factory=list)
-    rng: Sequence[RNGDevice] = Field(default_factory=list)
-    tpm: Sequence[TPMDevice] = Field(default_factory=list)
-    memballoon: Sequence[SimpleDevice] = Field(default_factory=list)
-    panic: Sequence[SimpleDevice] = Field(default_factory=list)
+    controllers: Sequence[ControllerDevice] = Field(
+        default_factory=list,
+        description='A list of controller devices for the domain.',
+    )
+    disks: Sequence[DiskDevice] = Field(
+        default_factory=list,
+        description='A list of disk devices for the domain.',
+    )
+    fs: Sequence[Filesystem] = Field(
+        default_factory=list,
+        description='A list of filesystems for the domain.',
+    )
+    net: Sequence[NetworkInterface] = Field(
+        default_factory=list,
+        description='A list of network interfaces for the domain.',
+    )
+    input: Sequence[InputDevice] = Field(
+        default_factory=list,
+        description='A list of input devices for the domain.',
+    )
+    graphics: Sequence[GraphicsDevice] = Field(
+        default_factory=list,
+        description='A list of graphics output devices for the domain.',
+    )
+    video: Sequence[VideoDevice] = Field(
+        default_factory=list,
+        description='A list of GPU devices for the domain.',
+    )
+    chardev: Sequence[CharacterDevice] = Field(
+        default_factory=list,
+        description='A list of character devices for the domain.',
+    )
+    watchdog: Sequence[WatchdogDevice] = Field(
+        default_factory=list,
+        description='A list of watchdog devices for the domain.',
+    )
+    rng: Sequence[RNGDevice] = Field(
+        default_factory=list,
+        description='A list of RNG devices for the domain.',
+    )
+    tpm: Sequence[TPMDevice] = Field(
+        default_factory=list,
+        description='A list of TPM devices for the domain.',
+    )
+    memballoon: Sequence[SimpleDevice] = Field(
+        default_factory=list,
+        description='A list of memory balloon devices for the domain.',
+    )
+    panic: Sequence[SimpleDevice] = Field(
+        default_factory=list,
+        description='A list of crash notifier devices for the domain.',
+    )
 
     @model_validator(mode='after')
     def check_controller_indices(self: Self) -> Self:
@@ -1240,7 +1931,7 @@ class Devices(BaseModel):
         return self
 
 
-class DomainInfo(BaseModel):
+class DomainInfo(Model):
     '''Model representing domain configuration for templating.
 
        Memory values should be provided in bytes unless otherwise noted.
@@ -1248,27 +1939,64 @@ class DomainInfo(BaseModel):
        A value of `0` for the `vcpu` property indicates that the count
        should be inferred from topology information in the `cpu` property
        if possible, otherwise a default value should be used.'''
-    name: str = Field(min_length=1)
-    type: Literal['hvf', 'kvm', 'lxc', 'vz', 'qemu', 'test', 'xen']
-    sub_template: str | None = Field(default=None)
-    uuid: UUID | None = Field(default=None)
-    genid: UUID | None = Field(default=None)
-    vcpu: int = Field(default=0, ge=0)
-    memory: int = Field(gt=0)
-    memtune: MemtuneInfo | None = Field(default=None)
-    cpu: CPUInfo | None = Field(default=None)
-    os: OSInfo
-    clock: ClockInfo = Field(default_factory=ClockInfo)
-    features: FeaturesInfo = Field(default_factory=FeaturesInfo)
-    devices: Devices = Field(default_factory=Devices)
+    name: NonEmptyString = Field(
+        description='The name of the domain to create.',
+    )
+    type: Literal['hvf', 'kvm', 'lxc', 'vz', 'qemu', 'test', 'xen'] = Field(
+        description='The domain type.',
+    )
+    uuid: UUID | None = Field(
+        default=None,
+        description='The UUID of the domain. If not specified, libvirt will auto-generate a UUID for the domain.',
+    )
+    genid: UUID | None = Field(
+        default=None,
+        description='The VM generation ID for the domain. If not specified, libvirt will auto-generate one for the domain.',
+    )
+    vcpu: int = Field(
+        default=0,
+        ge=0,
+        description='The number of virtual CPUs assigned to the domain. A value of 0 indicates that a sane value should be chosen based on any ' +
+                    'specified CPU topology.',
+    )
+    memory: int = Field(
+        gt=0,
+        description='The total amount of memory to assign to the domain, measured in bytes.',
+    )
+    memtune: MemtuneInfo | None = Field(
+        default=None,
+        description='Host-side memory limits for the domain. If not specified, no limits will be imposed.',
+    )
+    cpu: CPUInfo | None = Field(
+        default=None,
+        description='CPU configuration for domains that are virtual machines.',
+    )
+    os: OSFirmwareInfo | OSHostBootInfo | OSDirectBootInfo | OSContainerBootInfo | OSTestBootInfo = Field(
+        discriminator='variant',
+        description='Boot and firmware configuration for the domain.',
+    )
+    clock: ClockUTC | ClockLocal | ClockTimezone | ClockVariable | ClockAbsolute = Field(
+        discriminator='offset',
+        default=ClockUTC(offset='utc'),
+        description='Clock configuration for the domain.',
+    )
+    features: FeaturesInfo = Field(
+        default_factory=FeaturesInfo,
+        description='Feature configuration for the domain.',
+    )
+    devices: Devices = Field(
+        default_factory=Devices,
+        description='Device configuration for the domain. Note that libvirt may add additional devices beyond those listed in this configuration, ' +
+                    'dependent on the domain type and hypervisor.',
+    )
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def sub_template(self: Self) -> str:
+        return f'domain/{ self.type }.xml'
 
     @model_validator(mode='after')
-    def set_sub_template(self: Self) -> Self:
-        self.sub_template = f'domain/{ self.type }.xml'
-        return self
-
-    @model_validator(mode='after')
-    def fixup_vcpus(self: Self) -> Self:
+    def fixup_model(self: Self) -> Self:
         if self.cpu is not None:
             if self.vcpu == 0:
                 self.vcpu = self.cpu.topology.total_cpus

--- a/fvirt/templates/domain/_base.xml
+++ b/fvirt/templates/domain/_base.xml
@@ -23,7 +23,7 @@
     {% if on_lockfailure %}<on_lockfailure>{{ on_lockfailure }}</on_lockfailure>{% endif %}
     {% block cpu %}{% endblock %}
     {% if clock is defined %}
-        <clock offset='{{ clock.offset }}' {{ macros.add_attrs(clock, ('timezone', 'basis', 'adjustment', 'start')) }}>
+        <clock offset='{{ clock.offset }}' {{ macros.add_attrs(clock, ('timezone', 'basis', 'adjustment')) }}{% if clock.offset == 'absolute' %}{{ int(clock.start) }}{% endif %}>
             {% for timer in clock.timers %}
                 <timer {{ macros.add_attrs(timer, ('name', 'tickpolicy', 'track', 'present')) }} />
             {% endfor %}

--- a/fvirt/templates/domain/_macros.xml
+++ b/fvirt/templates/domain/_macros.xml
@@ -127,7 +127,7 @@
 {% macro input(idev) %}
     {% if idev.type == 'passthrough' %}
         <input type='{{ idev.type }}' {{ add_attrs(idev, ('bus', 'model')) }}>
-            <source evdev='{{ idev.src.dev }}' />
+            <source evdev='{{ idev.src }}' />
         </input>
     {% elif idev.type == 'evdev' %}
         <input type='{{ idev.type }}' {{ add_attrs(idev, ('bus', 'model')) }}>
@@ -142,11 +142,11 @@
     {% if 'listeners' in gdev %}
         {% for listen in gdev.listeners %}
             {% if listen.type == 'address' %}
-                <listen type='address' address='{{ listen.address }}' />
+                <listen type='address' address='{{ listen.listen }}' />
             {% elif listen.type == 'network' %}
-                <listen type='network' network='{{ listen.network }}' />
+                <listen type='network' network='{{ listen.listen }}' />
             {% elif listen.type == 'socket' %}
-                <listen type='socket' socket='{{ listen.socket }}' />
+                <listen type='socket' socket='{{ listen.listen }}' />
             {% elif listen.type == 'none' %}
                 <listen type='none' />
             {% endif %}
@@ -184,32 +184,32 @@
     </video>
 {% endmacro %}
 
-{% macro charsrc(type, src) %}
-    {% if type == 'pty' %}
+{% macro charsrc(src) %}
+    {% if src.type == 'pty' %}
         {% if 'path' in src %}
             <source path='{{ src.path }}' />
         {% endif %}
-    {% elif type in ('file', 'dev', 'pipe') %}
+    {% elif src.type in ('file', 'dev', 'pipe') %}
         <source path='{{ src.path }}' />
-    {% elif type == 'spiceport' %}
+    {% elif src.type == 'spiceport' %}
         <source channel='{{ src.channel }}' />
-    {% elif type == 'unix' %}
+    {% elif src.type == 'unix' %}
         <source mode='{{ src.mode }}' path='{{ src.path }}' />
-    {% elif type == 'tcp' %}
+    {% elif src.type == 'tcp' %}
         <source {{ add_attrs(src, ('mode', 'host', 'service', 'tls')) }} />
-    {% elif type == 'nmdm' %}
+    {% elif src.type == 'nmdm' %}
         <source master='{{ src.path }}A' slave='{{ src.path }}B' />
     {% endif %}
 {% endmacro %}
 
 {% macro chardev(cdev) %}
-    <{{ cdev.category }} type='{{ cdev.type }}'>
+    <{{ cdev.target.category }} type='{{ cdev.source.type }}'>
         <target {{ add_attrs(cdev.target, ('type', 'address', 'port', 'name', 'state')) }} />
-        {{ charsrc(cdev.type, cdev.source) }}
+        {{ charsrc(cdev.source) }}
         {% if 'log' in cdev %}
             <log file='{{ cdev.log.file }}'{% if 'append' in cdev.log %} append='{{ cdev.log.append }}'{% endif %} />
         {% endif %}
-    </{{ cdev.category }}>
+    </{{ cdev.target.category }}>
 {% endmacro %}
 
 {% macro watchdog(wdev) %}

--- a/fvirt/templates/domain/_vm.xml
+++ b/fvirt/templates/domain/_vm.xml
@@ -74,7 +74,14 @@
         {% endif %}
         </hyperv>
     {% endif %}
-    {% for feature in ('pvspinlock', 'hap', 'htm', 'vmcoreinfo', 'vmport', 'pmu', 'smm') %}
+    {% if 'smm' in features %}
+        <smm state='{{ features.smm.state }}'>
+            {% if 'tseg' in features.smm and features.smm.tseg %}
+                <tseg unit='bytes'>{{ features.smm.tseg }}</tseg>
+            {% endif %}
+        </smm>
+    {% endif %}
+    {% for feature in ('pvspinlock', 'hap', 'htm', 'vmcoreinfo', 'vmport', 'pmu') %}
         {% if feature in features %}
             <{{ feature }} state='{{ features[feature] }}' />
         {% endif %}

--- a/tests/data/cases/libvirt_models_domain.yaml
+++ b/tests/data/cases/libvirt_models_domain.yaml
@@ -8,29 +8,43 @@ PCIAddress:
       function: '0x0'
     - bus: '0x00'
       slot: '0x00'
-    - bus: '0xf8'
-      slot: '0x21'
-      function: '0xc'
-    - bus: '0x00'
-      slot: '0x00'
-      function: '0x0'
+    - bus: '0xff'
+      slot: '0x1f'
+      function: '0x7'
+    - <<: *pci_address
       domain: '0x0000'
-    - bus: '0x00'
-      slot: '0x00'
-      function: '0x0'
+    - <<: *pci_address
       multifunction: 'on'
-    - bus: '0x00'
-      slot: '0x00'
-      function: '0x0'
-      domain: '0x0000'
+    - <<: *pci_address
       multifunction: 'off'
-    - bus: '0x00'
-      slot: '0x00'
-      function: '0x0'
+    - <<: *pci_address
+      multifunction: true
+    - <<: *pci_address
+      multifunction: false
+    - <<: *pci_address
       domain: null
       multifunction: null
+    - bus: 0x00
+      slot: 0x00
+      function: 0x0
+      domain: 0x0000
+    - bus: 0xff
+      slot: 0x1f
+      function: 0x7
   invalid:
     - {}
+    - <<: *pci_address
+      bus: 0x1ff
+    - <<: *pci_address
+      bus: -1
+    - <<: *pci_address
+      slot: 0xff
+    - <<: *pci_address
+      slot: -1
+    - <<: *pci_address
+      function: 0xf
+    - <<: *pci_address
+      function: -1
     - bus: ''
       slot: '0x00'
       function: '0x0'
@@ -102,8 +116,6 @@ DataRate:
   valid:
     - bytes: 1
     - bytes: 1_000_000_000
-    - bytes: 1
-      period: null
     - &data_rate
       bytes: 1
       period: 1
@@ -142,7 +154,9 @@ CPUModelInfo:
     - name: test
       fallback: null
     - name: test
-      fallback: test
+      fallback: allow
+    - name: test
+      fallback: forbid
   invalid:
     - {}
     - name: ''
@@ -156,14 +170,12 @@ CPUTopology:
       dies: 2
       cores: 2
       threads: 2
-    - infer: threads
     - coalesce: sockets
   invalid:
     - sockets: 0
     - dies: 0
     - cores: 0
     - threads: 0
-    - infer: ''
     - coalesce: ''
   total_cpus:
     - - {}
@@ -202,7 +214,7 @@ CPUTopology:
 CPUInfo:
   valid:
     - {}
-    - mode: host
+    - mode: custom
       model:
         name: test
     - mode: null
@@ -280,7 +292,7 @@ OSContainerIDMapInfo:
       gid: null
     - uid: *idmap_entry
     - gid: *idmap_entry
-OSInfo:
+OSFirmwareInfo:
   valid:
     - variant: firmware
     - variant: firmware
@@ -298,31 +310,59 @@ OSInfo:
     - variant: firmware
       loader: *fwloader
       nvram: *fwnvram
+  invalid:
+    - {}
+    - variant: ''
+    - variant: firmware
+      loader: /nonexistent
+    - variant: firmware
+      nvram: *fwnvram
+OSHostBootInfo:
+  valid:
     - variant: host
       bootloader: /usr/bin/boot
     - variant: host
       bootloader: /usr/bin/boot
       bootloader_args: test
+  invalid:
+    - {}
+    - variant: ''
+    - variant: host
+    - variant: host
+      bootloader: ''
+OSDirectBootInfo:
+  valid:
     - variant: direct
-      kernel: test
+      kernel: /test
     - variant: direct
-      kernel: test
-      initrd: test
+      kernel: /test
+      initrd: /test
     - variant: direct
-      kernel: test
+      kernel: /test
       cmdline: test
     - variant: direct
-      kernel: test
-      dtb: test
+      kernel: /test
+      dtb: /test
     - variant: direct
-      kernel: test
-      loader: test
+      kernel: /test
+      loader: /test
     - variant: direct
-      kernel: test
-      initrd: test
+      kernel: /test
+      initrd: /test
       cmdline: test
-      dtb: test
-      loader: test
+      dtb: /test
+      loader: /test
+  invalid:
+    - {}
+    - variant: ''
+    - variant: direct
+    - variant: direct
+      kernel: ''
+    - variant: direct
+      kernel: test
+      loader: *fwloader
+OSContainerBootInfo:
+  valid:
     - &container_osinfo
       variant: container
       init: /sbin/init
@@ -335,63 +375,23 @@ OSInfo:
       inituser: root
       initgroup: root
       idmap: *idmap
+  invalid:
+    - {}
+    - variant: ''
+    - variant: container
+    - variant: container
+      init: ''
+OSTestBootInfo:
+  valid:
     - &test_osinfo
       variant: test
       arch: x86_64
   invalid:
     - {}
     - variant: ''
-    - variant: firmware
-      loader: /nonexistent
-    - variant: firmware
-      nvram: *fwnvram
-    - variant: firmware
-      bootloader: /usr/bin/boot
-    - variant: firmware
-      kernel: test
-    - variant: firmware
-      init: /sbin/init
-    - variant: host
-    - variant: host
-      bootloader: ''
-    - variant: host
-      loader: /nonexistent
-    - variant: host
-      loader: *fwloader
-    - variant: host
-      init: /sbin/init
-    - variant: direct
-    - variant: direct
-      kernel: ''
-    - variant: direct
-      kernel: test
-      bootloader: /usr/bin/boot
-    - variant: direct
-      kernel: test
-      init: /sbin/init
-    - variant: direct
-      kernel: test
-      loader: *fwloader
-    - variant: container
-    - variant: container
-      init: ''
-    - variant: container
-      loader: /nonexistent
-    - variant: container
-      loader: *fwloader
     - variant: test
     - variant: test
       arch: ''
-    - <<: *test_osinfo
-      loader: /nonexistent
-    - <<: *test_osinfo
-      loader: *fwloader
-    - <<: *test_osinfo
-      bootloader: /usr/bin/boot
-    - <<: *test_osinfo
-      kernel: test
-    - <<: *test_osinfo
-      init: /sbin/init
 ClockTimerInfo:
   valid:
     - name: platform
@@ -432,40 +432,87 @@ ClockTimerInfo:
       tickpolicy: ''
     - name: hpet
       present: ''
-ClockInfo:
+ClockUTC:
   valid:
-    - {}
     - offset: utc
+    - offset: utc
+      timers:
+        - *clock_timer
+  invalid:
+    - {}
+    - offset: ''
+ClockLocal:
+  valid:
     - offset: localtime
-    - offset: timezone
+    - offset: localtime
+      timers:
+        - *clock_timer
+  invalid:
+    - {}
+    - offset: ''
+ClockTimezone:
+  valid:
+    - &clock_tz
+      offset: timezone
       tz: America/New_York
+    - <<: *clock_tz
+      timers:
+        - *clock_timer
+  invalid:
+    - {}
+    - offset: ''
+    - offset: timezone
+    - offset: timezone
+      tz: ''
+ClockVariable:
+  valid:
+    - offset: variable
+    - offset: variable
+      basis: utc
+    - offset: variable
+      basis: localtime
+    - offset: variable
+      adjustment: 0
     - offset: variable
       basis: utc
       adjustment: 0
     - offset: variable
       basis: localtime
       adjustment: 0
-    - offset: absolute
-      start: 0
-    - offset: utc
+    - offset: variable
+      basis: utc
+      adjustment: -3600
+    - offset: variable
+      basis: localtime
+      adjustment: 3600
+    - offset: variable
       timers:
         - *clock_timer
   invalid:
+    - {}
     - offset: ''
-    - offset: timezone
-    - offset: timezone
-      tz: ''
-    - offset: variable
-      adjustment: 0
-    - offset: variable
-      basis: utc
     - offset: variable
       basis: ''
       adjustment: 0
     - offset: variable
       basis: utc
       adjustment: ''
+ClockAbsolute:
+  valid:
+    - &clock_absolute
+      offset: absolute
+      start: 0
     - offset: absolute
+      start: 1701357983
+    - <<: *clock_absolute
+      timers:
+        - *clock_timer
+  invalid:
+    - {}
+    - offset: ''
+    - offset: absolute
+    - offset: absolute
+      start: ''
 FeaturesHyperVSpinlocks:
   valid:
     - state: 'on'
@@ -660,6 +707,20 @@ FeaturesIOAPICInfo:
     - driver: 'qemu'
   invalid:
     - driver: ''
+FeaturesSMMConfig:
+  valid:
+    - state: 'on'
+    - state: 'off'
+    - &features_smm
+      state: 'on'
+      tseg: 16_777_216
+  invalid:
+    - {}
+    - state: ''
+    - state: 'on'
+      tseg: 0
+    - state: 'on'
+      tseg: -1
 FeaturesCapabilities:
   valid:
     - policy: allow
@@ -682,7 +743,8 @@ FeaturesCapabilities:
 FeaturesInfo:
   valid:
     - {}
-    - acpi: true
+    - &features
+      acpi: 'on'
       apic: *features_apic
       async_teardown: 'on'
       caps: *features_capabilities
@@ -691,15 +753,15 @@ FeaturesInfo:
       htm: 'on'
       hyperv: *features_hyperv
       kvm: *features_kvm
-      pae: true
+      pae: 'on'
       pmu: 'on'
       pvspinlock: 'on'
-      smm: 'on'
+      smm: *features_smm
       tcg: *features_tcg
       vmcoreinfo: 'on'
       vmport: 'on'
       xen: *features_xen
-    - acpi: false
+    - acpi: 'off'
       apic: {}
       async_teardown: 'off'
       gic: {}
@@ -707,14 +769,33 @@ FeaturesInfo:
       htm: 'off'
       hyperv: {}
       kvm: {}
-      pae: false
+      pae: 'off'
       pmu: 'off'
       pvspinlock: 'off'
-      smm: 'off'
       tcg: {}
       vmcoreinfo: 'off'
       vmport: 'off'
       xen: {}
+    - <<: *features
+      acpi: true
+      async_teardown: true
+      hap: true
+      htm: true
+      pae: true
+      pmu: true
+      pvspinlock: true
+      vmcoreinfo: true
+      vmport: true
+    - <<: *features
+      acpi: false
+      async_teardown: false
+      hap: false
+      htm: false
+      pae: false
+      pmu: false
+      pvspinlock: false
+      vmcoreinfo: false
+      vmport: false
   invalid:
     - acpi: ''
     - async_teardown: ''
@@ -741,6 +822,123 @@ ControllerDriverInfo:
     - queues: 0
     - cmd_per_lun: 0
     - max_sectors: 0
+SimpleController:
+  valid:
+    - type: fdc
+    - type: sata
+    - type: ccid
+    - type: fdc
+      index: 0
+    - type: sata
+      index: 0
+    - type: ccid
+      index: 0
+  invalid:
+    - {}
+    - type: ''
+    - type: scsi
+    - type: usb
+    - type: virtio-serial
+    - type: xenbus
+    - type: fdc
+      index: -1
+    - type: sata
+      index: -1
+    - type: ccid
+      index: -1
+XenBusController:
+  valid:
+    - type: xenbus
+    - type: xenbus
+      index: 0
+    - type: xenbus
+      maxGrantFrames: 64
+    - type: xenbus
+      maxEventChannels: 64
+  invalid:
+    - {}
+    - type: ''
+    - type: xenbus
+      index: -1
+    - type: xenbus
+      maxGrantFrames: 0
+    - type: xenbus
+      maxEventChannels: 0
+IDEController:
+  valid:
+    - type: ide
+    - type: ide
+      index: 0
+    - type: ide
+      model: piix4
+  invalid:
+    - {}
+    - type: ''
+    - type: ide
+      index: -1
+    - type: ide
+      model: ''
+SCSIController:
+  valid:
+    - type: scsi
+    - type: scsi
+      index: 0
+    - type: scsi
+      model: virtio
+    - type: scsi
+      driver: *controller_driver
+  invalid:
+    - {}
+    - type: ''
+    - type: scsi
+      index: -1
+    - type: scsi
+      model: ''
+    - type: scsi
+      driver: ''
+USBController:
+  valid:
+    - type: usb
+    - type: usb
+      index: 0
+    - type: usb
+      model: qemu-xhci
+    - type: usb
+      model: none
+    - type: usb
+      ports: 4
+  invalid:
+    - {}
+    - type: ''
+    - type: usb
+      index: -1
+    - type: usb
+      model: ''
+    - type: usb
+      ports: 0
+VirtIOSerialController:
+  valid:
+    - type: virtio-serial
+    - type: virtio-serial
+      index: 0
+    - type: virtio-serial
+      model: virtio-non-transitional
+    - type: virtio-serial
+      ports: 4
+      vectors: 4
+  invalid:
+    - {}
+    - type: ''
+    - type: virtio-serial
+      index: -1
+    - type: virtio-serial
+      model: ''
+    - type: virtio-serial
+      ports: 0
+      vectors: 4
+    - type: virtio-serial
+      ports: 4
+      vectors: 0
 ControllerDevice:
   valid:
     - type: scsi
@@ -780,7 +978,7 @@ ControllerDevice:
       driver: ''
 DiskVolumeSrcInfo:
   valid:
-    - &disk_pool_src
+    - &disk_volume_src
       pool: test
       volume: test
   invalid:
@@ -802,8 +1000,10 @@ DiskTargetInfo:
       bus: virtio
       addr: *pci_address
     - dev: /dev/sda
+      bus: usb
       removable: 'on'
     - dev: /dev/sda
+      bus: scsi
       removable: 'off'
     - dev: /dev/sda
       rotation_rate: 1
@@ -821,50 +1021,47 @@ DiskTargetInfo:
       bus: scsi
       addr: *pci_address
     - dev: /dev/sda
+      removable: 'on'
+    - dev: /dev/sda
+      bus: usb
       removable: ''
     - dev: /dev/sda
       rotation_rate: 0
     - dev: /dev/sda
       rotation_rate: 65536
-DiskDevice:
+FileDisk:
   valid:
-    - &disk_device
+    - &file_disk
       type: file
       src: /nonexistent
       target: *disk_target
-    - type: volume
-      src: *disk_pool_src
-      target: *disk_target
-    - type: block
-      src: /dev/sda
-      target: *disk_target
-    - <<: *disk_device
+    - <<: *file_disk
       boot: 1
-    - <<: *disk_device
+    - <<: *file_disk
       device: disk
-    - <<: *disk_device
+    - <<: *file_disk
       device: cdrom
-    - <<: *disk_device
+    - <<: *file_disk
       device: floppy
-    - <<: *disk_device
+    - <<: *file_disk
       device: lun
-    - <<: *disk_device
+    - <<: *file_disk
       readonly: true
-    - <<: *disk_device
+    - <<: *file_disk
       readonly: false
-    - <<: *disk_device
+    - <<: *file_disk
       snapshot: internal
-    - <<: *disk_device
+    - <<: *file_disk
       snapshot: external
-    - <<: *disk_device
+    - <<: *file_disk
       snapshot: manual
-    - <<: *disk_device
+    - <<: *file_disk
       snapshot: 'no'
-    - <<: *disk_device
+    - <<: *file_disk
       startup: mandatory
-    - <<: *disk_device
+    - <<: *file_disk
       startup: requisite
-    - <<: *disk_device
+    - <<: *file_disk
       startup: optional
   invalid:
     - {}
@@ -880,26 +1077,124 @@ DiskDevice:
       src: /nonexistent
     - src: /nonexistent
       target: *disk_target
-    - type: file
-      src: *disk_pool_src
-      target: *disk_target
-    - type: volume
-      src: /nonexistent
-      target: *disk_target
-    - <<: *disk_device
+    - <<: *file_disk
       boot: 0
-    - <<: *disk_device
+    - <<: *file_disk
       readonly: ''
-    - <<: *disk_device
+    - <<: *file_disk
       device: ''
-    - <<: *disk_device
+    - <<: *file_disk
       snapshot: ''
-    - <<: *disk_device
+    - <<: *file_disk
       startup: ''
-    - type: block
+BlockDisk:
+  valid:
+    - &block_disk
+      type: block
       src: /dev/sda
       target: *disk_target
+    - <<: *block_disk
+      boot: 1
+    - <<: *block_disk
+      device: disk
+    - <<: *block_disk
+      device: cdrom
+    - <<: *block_disk
+      device: floppy
+    - <<: *block_disk
+      device: lun
+    - <<: *block_disk
+      readonly: true
+    - <<: *block_disk
+      readonly: false
+    - <<: *block_disk
+      snapshot: internal
+    - <<: *block_disk
+      snapshot: external
+    - <<: *block_disk
+      snapshot: manual
+    - <<: *block_disk
+      snapshot: 'no'
+  invalid:
+    - {}
+    - type: ''
+      src: /dev/sda
+      target: *disk_target
+    - type: block
+      src: ''
+      target: *disk_target
+    - type: block
+      target: *disk_target
+    - type: block
+      src: /dev/sda
+    - src: /dev/sda
+      target: *disk_target
+    - <<: *block_disk
+      boot: 0
+    - <<: *block_disk
+      readonly: ''
+    - <<: *block_disk
+      device: ''
+    - <<: *block_disk
+      snapshot: ''
+VolumeDisk:
+  valid:
+    - &volume_disk
+      type: volume
+      src: *disk_volume_src
+      target: *disk_target
+    - <<: *volume_disk
+      boot: 1
+    - <<: *volume_disk
+      device: disk
+    - <<: *volume_disk
+      device: cdrom
+    - <<: *volume_disk
+      device: floppy
+    - <<: *volume_disk
+      device: lun
+    - <<: *volume_disk
+      readonly: true
+    - <<: *volume_disk
+      readonly: false
+    - <<: *volume_disk
+      snapshot: internal
+    - <<: *volume_disk
+      snapshot: external
+    - <<: *volume_disk
+      snapshot: manual
+    - <<: *volume_disk
+      snapshot: 'no'
+    - <<: *volume_disk
+      startup: mandatory
+    - <<: *volume_disk
       startup: requisite
+    - <<: *volume_disk
+      startup: optional
+  invalid:
+    - {}
+    - type: ''
+      src: *disk_volume_src
+      target: *disk_target
+    - type: volume
+      src: ''
+      target: *disk_target
+    - type: volume
+      target: *disk_target
+    - type: volume
+      src: *disk_volume_src
+    - src: *disk_volume_src
+      target: *disk_target
+    - <<: *volume_disk
+      boot: 0
+    - <<: *volume_disk
+      readonly: ''
+    - <<: *volume_disk
+      device: ''
+    - <<: *volume_disk
+      snapshot: ''
+    - <<: *volume_disk
+      startup: ''
 FilesystemDriverInfo:
   valid:
     - &filesystem_driver
@@ -1037,18 +1332,17 @@ NetworkVPort:
       typeidversion: 0
     - type: '802.1Qbh'
       profileid: ''
-NetworkIPInfo:
+NetworkIPv4Info:
   valid:
     - &ipv4_address_info
       address: &ipv4_address '192.0.2.1'
       prefix: 24
+  invalid:
+    - {}
     - &ipv6_address_info
       address: &ipv6_address '2001::db8:1'
       prefix: 64
-  invalid:
-    - {}
     - address: *ipv4_address
-    - address: *ipv6_address
     - prefix: 24
     - address: ''
       prefix: 24
@@ -1056,73 +1350,167 @@ NetworkIPInfo:
       prefix: 0
     - <<: *ipv4_address_info
       prefix: 32
+NetworkIPv6Info:
+  valid:
+    - *ipv6_address_info
+  invalid:
+    - {}
+    - *ipv4_address_info
+    - prefix: 64
+    - address: ''
+      prefix: 64
     - <<: *ipv6_address_info
       prefix: 0
     - <<: *ipv6_address_info
       prefix: 128
-NetworkInterface:
+VirtualInterface:
   valid:
-    - type: network
-    - type: network
+    - &virtual_interface
+      type: network
       src: test
-    - type: network
+    - <<: *virtual_interface
       target: eth0
-    - type: network
-      mac: '02:00:00:00:00:01'
-    - type: network
+    - <<: *virtual_interface
+      mac: &mac_address '02:00:00:00:00:01'
+    - <<: *virtual_interface
       boot: 1
-    - type: network
+    - <<: *virtual_interface
       virtualport: *vport_basic
-    - type: bridge
-    - type: bridge
-      virtualport: *vport_ovs
-    - type: direct
-      mode: vepa
-    - type: direct
-      mode: bridge
-    - type: direct
-      mode: private
-    - type: direct
-      mode: passthrough
-    - type: user
-      ipv4: *ipv4_address_info
-    - type: user
-      ipv6: *ipv6_address_info
-    - type: user
-      ipv4: *ipv4_address_info
-      ipv6: *ipv6_address_info
   invalid:
     - {}
     - type: ''
     - type: network
+    - type: network
       src: ''
-    - type: network
+    - src: test
+    - <<: *virtual_interface
       target: ''
-    - type: network
+    - <<: *virtual_interface
       mac: ''
-    - type: network
-      mac: '02:00:00:00:00:0z'
-    - type: network
+    - <<: *virtual_interface
+      mac: &invalid_mac '02:00:00:00:00:0z'
+    - <<: *virtual_interface
       boot: 0
-    - type: network
+BridgeInterface:
+  valid:
+    - &bridge_interface
+      type: bridge
+      src: br0
+    - <<: *bridge_interface
+      target: eth0
+    - <<: *bridge_interface
+      mac: *mac_address
+    - <<: *bridge_interface
+      boot: 1
+    - <<: *bridge_interface
+      virtualport: *vport_ovs
+  invalid:
+    - {}
+    - type: ''
+    - type: bridge
+    - type: bridge
+      src: ''
+    - src: br0
+    - <<: *bridge_interface
+      target: ''
+    - <<: *bridge_interface
+      mac: ''
+    - <<: *bridge_interface
+      mac: *invalid_mac
+    - <<: *bridge_interface
+      boot: 0
+DirectInterface:
+  valid:
+    - &direct_interface
+      type: direct
+      src: eth0
+    - <<: *direct_interface
+      mode: vepa
+    - <<: *direct_interface
+      mode: bridge
+    - <<: *direct_interface
+      mode: private
+    - <<: *direct_interface
       mode: passthrough
+    - <<: *direct_interface
+      target: eth0
+    - <<: *direct_interface
+      mac: *mac_address
+    - <<: *direct_interface
+      boot: 1
+    - <<: *direct_interface
+      mode: vepa
+      virtualport: *vport_vepa
+  invalid:
+    - {}
+    - type: ''
     - type: direct
     - type: direct
+      src: ''
+    - src: test
+    - <<: *direct_interface
       mode: ''
-    - type: direct
+    - <<: *direct_interface
+      target: ''
+    - <<: *direct_interface
+      mac: ''
+    - <<: *direct_interface
+      mac: *invalid_mac
+    - <<: *direct_interface
+      boot: 0
+UserInterface:
+  valid:
+    - type: user
       ipv4: *ipv4_address_info
-    - type: direct
+    - type: user
       ipv6: *ipv6_address_info
+    - &user_interface
+      type: user
+      ipv4: *ipv4_address_info
+      ipv6: *ipv6_address_info
+    - <<: *user_interface
+      target: eth0
+    - <<: *user_interface
+      mac: *mac_address
+    - <<: *user_interface
+      boot: 1
+  invalid:
+    - {}
+    - type: ''
     - type: user
-      ipv4: ''
     - type: user
-      ipv6: ''
-    - type: user
-      ipv4: {}
-    - type: user
-      ipv6: {}
-    - type: user
-      mode: passthrough
+      src: ''
+    - src: test
+    - <<: *user_interface
+      target: ''
+    - <<: *user_interface
+      mac: ''
+    - <<: *user_interface
+      mac: *invalid_mac
+    - <<: *user_interface
+      boot: 0
+NullInterface:
+  valid:
+    - &null_interface
+      type: 'null'
+    - type: null
+    - <<: *null_interface
+      target: eth0
+    - <<: *null_interface
+      mac: *mac_address
+    - <<: *null_interface
+      boot: 1
+  invalid:
+    - {}
+    - type: ''
+    - <<: *null_interface
+      target: ''
+    - <<: *null_interface
+      mac: ''
+    - <<: *null_interface
+      mac: *invalid_mac
+    - <<: *null_interface
+      boot: 0
 InputSource:
   valid:
     - &input_source
@@ -1144,7 +1532,7 @@ InputSource:
       repeat: ''
     - <<: *input_source
       grabToggle: ''
-InputDevice:
+SimpleInputDevice:
   valid:
     - type: keyboard
     - type: mouse
@@ -1153,18 +1541,13 @@ InputDevice:
       bus: usb
     - type: keyboard
       bus: ps2
-    - &input_device
+    - &simple_input
       type: keyboard
       bus: virtio
     - type: keyboard
       bus: xen
-    - type: keyboard
-      bus: virtio
+    - <<: *simple_input
       model: virtio
-    - type: passthrough
-      src: *input_source
-    - type: evdev
-      src: *input_source
   invalid:
     - {}
     - type: ''
@@ -1173,148 +1556,192 @@ InputDevice:
     - type: keyboard
       bus: virtio
       model: ''
-    - type: keyboard
-      src: *input_source
-    - type: passthrough
-    - type: evdev
-GraphicsListener:
+PassthroughInputDevice:
   valid:
-    - &graphics_listener
-      type: none
-    - type: address
-      address: *ipv4_address
-    - type: address
-      address: *ipv6_address
-    - type: network
-      network: test
-    - type: socket
-      socket: /tmp/test.sock
+    - &passthrough_input
+      type: passthrough
+      src: /dev/input/event0
+    - <<: *passthrough_input
+      bus: usb
+    - <<: *passthrough_input
+      bus: ps2
+    - <<: *passthrough_input
+      bus: virtio
+    - <<: *passthrough_input
+      bus: xen
+    - <<: *passthrough_input
+      bus: virtio
+      model: virtio
   invalid:
     - {}
     - type: ''
-    - type: none
-      address: *ipv4_address
-    - type: none
-      network: test
-    - type: none
-      socket: /tmp/test.sock
+    - type: passthrough
+      src: ''
+    - <<: *passthrough_input
+      bus: ''
+    - <<: *passthrough_input
+      bus: virtio
+      model: ''
+EvdevInputDevice:
+  valid:
+    - &evdev_input
+      type: evdev
+      src: *input_source
+    - <<: *evdev_input
+      bus: usb
+    - <<: *evdev_input
+      bus: ps2
+    - <<: *evdev_input
+      bus: virtio
+    - <<: *evdev_input
+      bus: xen
+    - <<: *evdev_input
+      bus: virtio
+      model: virtio
+  invalid:
+    - {}
+    - type: ''
+    - type: evdev
+      src: ''
+    - <<: *evdev_input
+      bus: ''
+    - <<: *evdev_input
+      bus: virtio
+      model: ''
+NullGraphicsListener:
+  valid:
+    - &graphics_listener
+      type: none
+  invalid:
+    - {}
+    - type: ''
+AddressGraphicsListener:
+  valid:
     - type: address
-      address: ''
+      listen: *ipv4_address
     - type: address
+      listen: *ipv6_address
+  invalid:
+    - {}
+    - type: ''
     - type: address
-      network: test
-    - type: address
-      socket: /tmp/test.sock
+      listen: ''
+NetworkGraphicsListener:
+  valid:
     - type: network
-      network: ''
+      listen: test
+  invalid:
+    - {}
+    - type: ''
     - type: network
-    - type: network
-      address: *ipv4_address
-    - type: network
-      socket: /tmp/test.sock
+      listen: ''
+SocketGraphicsListener:
+  valid:
     - type: socket
-      socket: ''
+      listen: /run/graphics.sock
+  invalid:
+    - {}
+    - type: ''
     - type: socket
-    - type: socket
-      address: *ipv4_address
-    - type: socket
-      network: test
-GraphicsDevice:
+      listen: ''
+VNCGraphics:
   valid:
     - type: vnc
-    - type: spice
-    - type: rdp
-    - &gd_case0
-      type: vnc
+    - type: vnc
       listeners:
         - *graphics_listener
-    - <<: *gd_case0
-      type: spice
-    - <<: *gd_case0
-      type: rdp
-    - &gd_case1
-      type: vnc
+    - type: vnc
       port: 5900
-    - <<: *gd_case1
-      type: spice
-    - <<: *gd_case1
-      type: rdp
-    - &gd_case2
-      type: vnc
+    - type: vnc
       autoport: 'yes'
-    - <<: *gd_case2
-      type: spice
-    - <<: *gd_case2
-      type: rdp
-    - &gd_case3
-      type: vnc
+    - type: vnc
       port: 5900
       autoport: 'no'
-    - <<: *gd_case3
-      type: spice
-    - <<: *gd_case3
-      type: rdp
-    - &gd_case4
+    - type: vnc
+      keymap: us
+    - &vnc_passwd
       type: vnc
-      socket: /run/vnc.sock
-    - <<: *gd_case4
-      type: spice
-    - <<: *gd_case4
-      type: rdp
+      passwd: secret
+    - <<: *vnc_passwd
+      passwdValidTo: '2023-12-31T00:00:00'
+    - <<: *vnc_passwd
+      connected: keep
+    - <<: *vnc_passwd
+      connected: disconnect
+    - <<: *vnc_passwd
+      connected: fail
     - type: vnc
       websocket: 5900
-    - &gd_case5
-      type: vnc
-      passwd: secret
-    - <<: *gd_case5
-      type: spice
-    - <<: *gd_case5
-      type: rdp
-    - &gd_case6
-      type: vnc
-      passwd: secret
-      passwdValidTo: '2023-12-31T00:00:00'
-    - <<: *gd_case6
-      type: spice
-    - <<: *gd_case6
-      type: rdp
-    - &gd_case7
-      type: vnc
-      passwd: secret
-      connected: keep
-    - <<: *gd_case7
-      type: spice
-    - <<: *gd_case7
-      type: rdp
-    - &gd_case8
-      type: vnc
-      passwd: secret
-      connected: disconnect
-    - <<: *gd_case8
-      type: spice
-    - <<: *gd_case8
-      type: rdp
-    - &gd_case9
-      type: vnc
-      passwd: secret
-      connected: fail
-    - <<: *gd_case9
-      type: spice
-    - <<: *gd_case9
-      type: rdp
-    - &gd_case10
-      type: vnc
-      keymap: us
-    - <<: *gd_case10
-      type: spice
-    - <<: *gd_case10
-      type: rdp
     - type: vnc
       sharePolicy: allow-exclusive
     - type: vnc
       sharePolicy: force-shared
     - type: vnc
       sharePolicy: ignore
+    - type: vnc
+      powerControl: 'yes'
+    - type: vnc
+      powerControl: 'no'
+  invalid:
+    - {}
+    - type: ''
+    - type: vnc
+      port: 0
+    - type: vnc
+      port: -1
+    - type: vnc
+      port: 65536
+    - type: vnc
+      port: 5900
+      autoport: 'yes'
+    - type: vnc
+      autoport: ''
+    - type: vnc
+      keymap: ''
+    - type: vnc
+      passwdValidTo: '2023-12-31T00:00:00'
+    - type: vnc
+      connected: keep
+    - <<: *vnc_passwd
+      passwdValidTo: ''
+    - <<: *vnc_passwd
+      connected: ''
+    - type: vnc
+      socket: ''
+    - type: vnc
+      websocket: -2
+    - type: vnc
+      websocket: 65536
+    - type: vnc
+      sharePolicy: ''
+    - type: vnc
+      powerControl: ''
+SPICEGraphics:
+  valid:
+    - type: spice
+    - type: spice
+      listeners:
+        - *graphics_listener
+    - type: spice
+      port: 5900
+    - type: spice
+      autoport: 'yes'
+    - type: spice
+      port: 5900
+      autoport: 'no'
+    - type: spice
+      keymap: us
+    - &spice_passwd
+      type: spice
+      passwd: secret
+    - <<: *spice_passwd
+      passwdValidTo: '2023-12-31T00:00:00'
+    - <<: *spice_passwd
+      connected: keep
+    - <<: *spice_passwd
+      connected: disconnect
+    - <<: *spice_passwd
+      connected: fail
     - type: spice
       tlsPort: 5900
     - type: spice
@@ -1329,49 +1756,30 @@ GraphicsDevice:
       channels:
         main: secure
         record: insecure
-    - type: rdp
-      multiUser: 'yes'
-    - type: rdp
-      multiUser: 'no'
-    - type: rdp
-      multiUser: 'yes'
-      replaceUser: 'yes'
-    - type: rdp
-      multiUser: 'yes'
-      replaceUser: 'no'
   invalid:
     - {}
     - type: ''
-    - type: vnc
+    - type: spice
       port: 0
-    - type: vnc
+    - type: spice
       port: -1
-    - type: vnc
+    - type: spice
       port: 65536
-    - type: vnc
+    - type: spice
+      port: 5900
+      autoport: 'yes'
+    - type: spice
       autoport: ''
-    - type: vnc
-      socket: ''
-    - type: vnc
-      websocket: -2
-    - type: vnc
-      websocket: 65536
-    - type: vnc
-      passwd: secret
-      passwdValidTo: ''
-    - type: vnc
-      passwdValidTo: '2023-12-31T00:00:00'
-    - type: vnc
+    - type: spice
       keymap: ''
-    - type: vnc
+    - type: spice
+      passwdValidTo: '2023-12-31T00:00:00'
+    - type: spice
       connected: keep
-    - type: vnc
-      passwd: secret
+    - <<: *spice_passwd
+      passwdValidTo: ''
+    - <<: *spice_passwd
       connected: ''
-    - type: vnc
-      sharePolicy: ''
-    - type: vnc
-      powerControl: ''
     - type: spice
       tlsPort: 0
     - type: spice
@@ -1379,17 +1787,81 @@ GraphicsDevice:
     - type: spice
       defaultMode: ''
     - type: spice
-      channels: []
+      channels: ''
     - type: spice
       channels:
         main: ''
+RDPGraphics:
+  valid:
+    - type: rdp
+    - type: rdp
+      listeners:
+        - *graphics_listener
+    - type: rdp
+      port: 3389
+    - type: rdp
+      autoport: 'yes'
+    - type: rdp
+      port: 3389
+      autoport: 'no'
+    - &rdp_passwd
+      type: rdp
+      passwd: secret
+    - <<: *rdp_passwd
+      passwdValidTo: '2023-12-31T00:00:00'
+    - <<: *rdp_passwd
+      connected: keep
+    - <<: *rdp_passwd
+      connected: disconnect
+    - <<: *rdp_passwd
+      connected: fail
+    - type: rdp
+      multiUser: 'yes'
+    - type: rdp
+      multiUser: 'no'
+    - type: rdp
+      multiUser: 'no'
+      replaceUser: 'yes'
+    - type: rdp
+      multiUser: 'no'
+      replaceUser: 'no'
+  invalid:
+    - {}
+    - type: ''
+    - type: rdp
+      port: 0
+    - type: rdp
+      port: -1
+    - type: rdp
+      port: 65536
+    - type: rdp
+      port: 3389
+      autoport: 'yes'
+    - type: rdp
+      autoport: ''
+    - type: rdp
+      passwdValidTo: '2023-12-31T00:00:00'
+    - type: rdp
+      connected: keep
+    - <<: *rdp_passwd
+      passwdValidTo: ''
+    - <<: *rdp_passwd
+      connected: ''
     - type: rdp
       multiUser: ''
     - type: rdp
+      multiUser: 'no'
+      replaceUser: ''
+    - type: rdp
+      replaceUser: 'yes'
+    - type: rdp
+      replaceUser: 'no'
+    - type: rdp
+      multiUser: 'yes'
       replaceUser: 'yes'
     - type: rdp
       multiUser: 'yes'
-      replaceUser: ''
+      replaceUser: 'no'
 VideoDevice:
   valid:
     - type: vga
@@ -1429,97 +1901,229 @@ VideoDevice:
       blob: 'on'
     - type: virtio
       blob: ''
-CharDevSource:
+CharDevSimpleSource:
   valid:
-    - &char_dev_path_source
-      path: /nonexistent
-    - &char_dev_socket_source
-      path: /run/char.sock
-      mode: bind
-    - path: /run/char.sock
-      mode: connect
-    - &char_dev_channel_source
-      channel: org.qemu.console.serial.0
-    - &char_dev_net_source
-      host: console.example.com
-      mode: connect
-      service: 23
-    - host: console.example.com
-      mode: bind
-      service: 23
-    - <<: *char_dev_net_source
-      tls: 'no'
-    - <<: *char_dev_net_source
-      tls: 'yes'
+    - type: null
+    - type: 'null'
+    - type: vc
+    - type: stdio
   invalid:
     - {}
-    - path: ''
-    - path: '/run/char.sock'
-      mode: ''
-    - path: /nonexistent
-      channel: org.qemu.console.serial.0
-    - path: /nonexistent
-      service: 23
-    - path: /nonexistent
-      tls: 'yes'
-    - host: console.example.com
-      service: 23
-    - host: console.example.com
-      mode: connect
-    - host: console.example.com
-      mode: connect
-      service: 0
-    - host: console.example.com
-      mode: connect
-      service: 65536
-    - host: console.example.com
-      mode: ''
-      service: 23
-    - <<: *char_dev_net_source
-      tls: ''
-    - <<: *char_dev_channel_source
-      mode: connect
-    - <<: *char_dev_channel_source
-      service: 23
-    - <<: *char_dev_channel_source
-      tls: 'yes'
-CharDevTarget:
+    - type: ''
+CharDevPathSource:
   valid:
-    - &char_dev_target_simple
+    - type: file
+      path: /nonexistent
+    - type: dev
+      path: /dev/ttyS0
+    - type: pipe
+      path: /nonexistent
+  invalid:
+    - {}
+    - type: ''
+      path: /nonexistent
+    - type: file
+      path: ''
+    - type: dev
+      path: ''
+    - type: pipe
+      path: ''
+CharDevPTYSource:
+  valid:
+    - &char_dev_source
+      type: pty
+    - type: pty
+      path: /dev/pty/3
+  invalid:
+    - {}
+    - type: ''
+    - type: pty
+      path: ''
+CharDevSocketSource:
+  valid:
+    - type: unix
+      path: /run/serial.sock
+      mode: bind
+    - type: unix
+      path: /run/serial.sock
+      mode: connect
+  invalid:
+    - {}
+    - type: ''
+    - type: unix
+      path: ''
+      mode: bind
+    - type: unix
+      path: /run/serial.sock
+      mode: ''
+CharDevTCPSource:
+  valid:
+    - type: tcp
+      host: *ipv4_address
+      service: 23
+      mode: bind
+    - type: tcp
+      host: *ipv4_address
+      service: 23
+      mode: connect
+    - type: tcp
+      host: *ipv6_address
+      service: 23
+      mode: bind
+    - type: tcp
+      host: *ipv6_address
+      service: 23
+      mode: connect
+  invalid:
+    - {}
+    - type: tcp
+      host: ''
+      service: 23
+      mode: connect
+    - type: tcp
+      host: *ipv4_address
+      service: 0
+      mode: bind
+    - type: tcp
+      host: *ipv4_address
+      service: 65536
+      mode: bind
+    - type: tcp
+      host: *ipv4_address
+      service: 23
+      mode: ''
+CharDevChannelSource:
+  valid:
+    - type: spiceport
+      channel: org.qemu.console.serial.0
+  invalid:
+    - {}
+    - type: ''
+      channel: org.qemu.console.serial.0
+    - type: channel
+      channel: org.qemu.console.serial.0
+    - type: spiceport
+      channel: ''
+ParallelDevTarget:
+  valid:
+    - category: parallel
       port: 0
-    - port: 0
+  invalid:
+    - {}
+    - category: ''
+      port: 0
+    - category: parallel
+      port: -1
+SerialDevTarget:
+  valid:
+    - &char_dev_target
+      category: serial
+      port: 0
+    - <<: *char_dev_target
+      type: usb-serial
+  invalid:
+    - {}
+    - category: ''
+      port: 0
+    - category: serial
+      port: -1
+    - <<: *char_dev_target
+      type: ''
+ConsoleDevTarget:
+  valid:
+    - category: console
+      type: serial
+      port: 0
+    - category: console
       type: virtio
-    - &char_dev_target_guestfwd
+      port: 0
+    - category: console
+      type: xen
+      port: 0
+    - category: console
+      type: lxc
+      port: 0
+    - category: console
+      type: openvz
+      port: 0
+    - category: console
+      type: sclp
+      port: 0
+    - category: console
+      type: sclplm
+      port: 0
+  invalid:
+    - {}
+    - category: console
+    - type: serial
+    - category: ''
+      type: serial
+    - category: console
+      type: ''
+NetChannelDevTarget:
+  valid:
+    - category: channel
       type: guestfwd
       address: *ipv4_address
       port: 80
-    - <<: *char_dev_target_guestfwd
+    - category: channel
+      type: guestfwd
       address: *ipv6_address
-    - &char_dev_target_channel
-      name: org.qemu.guest_agent.0
-    - <<: *char_dev_target_channel
-      type: virtio
+      port: 80
   invalid:
     - {}
-    - port: -1
-    - port: 0
-      name: org.qemu.guest_agent.0
-    - type: guestfwd
-      address: *ipv4_address
-    - address: *ipv4_address
-      port: 80
-    - type: virtio
+    - category: ''
+      type: guestfwd
       address: *ipv4_address
       port: 80
-    - type: guestfwd
+    - category: channel
+      type: ''
+      address: *ipv4_address
+      port: 80
+    - category: channel
+      type: guestfwd
+      address: ''
+      port: 80
+    - category: channel
+      type: guestfwd
       address: *ipv4_address
       port: 0
-    - type: guestfwd
+    - category: channel
+      type: guestfwd
       address: *ipv4_address
       port: 65536
-    - <<: *char_dev_target_guestfwd
+VirtIOChannelDevTarget:
+  valid:
+    - category: channel
+      type: virtio
       name: org.qemu.guest_agent.0
-    - name: ''
+  invalid:
+    - {}
+    - category: ''
+      type: virtio
+      name: org.qemu.guest_agent.0
+    - category: channel
+      type: ''
+      name: org.qemu.guest_agent.0
+    - category: channel
+      type: virtio
+      name: ''
+XenChannelDevTarget:
+  valid:
+    - category: channel
+      type: xen
+      name: org.qemu.guest_agent.0
+  invalid:
+    - {}
+    - category: ''
+      type: xen
+      name: org.qemu.guest_agent.0
+    - category: channel
+      type: ''
+      name: org.qemu.guest_agent.0
+    - category: channel
+      type: xen
+      name: ''
 CharDevLog:
   valid:
     - &char_dev_log
@@ -1535,141 +2139,20 @@ CharDevLog:
       append: ''
 CharacterDevice:
   valid:
-    - &serial_dev
-      category: serial
-      type: 'null'
-      target: *char_dev_target_simple
-    - &parallel_dev
-      <<: *serial_dev
-      category: parallel
-    - &console_dev
-      <<: *serial_dev
-      category: console
-    - &channel_dev
-      category: channel
-      type: 'null'
-      target: *char_dev_target_channel
-    - <<: *serial_dev
+    - target: *char_dev_target
+    - target: *char_dev_target
+      source: *char_dev_source
+    - target: *char_dev_target
       log: *char_dev_log
-    - <<: *serial_dev
-      type: stdio
-    - <<: *serial_dev
-      type: vc
-    - <<: *serial_dev
-      type: pty
-    - <<: *serial_dev
-      type: file
-      src: *char_dev_path_source
-    - <<: *serial_dev
-      type: dev
-      src: *char_dev_path_source
-    - <<: *serial_dev
-      type: pipe
-      src: *char_dev_path_source
-    - <<: *serial_dev
-      type: nmdm
-      src: *char_dev_path_source
-    - <<: *serial_dev
-      type: pty
-      src: *char_dev_path_source
-    - <<: *serial_dev
-      type: tcp
-      src: *char_dev_net_source
-    - <<: *serial_dev
-      type: unix
-      src: *char_dev_socket_source
-    - <<: *serial_dev
-      type: spiceport
-      src: *char_dev_channel_source
+    - target: *char_dev_target
+      source: *char_dev_source
+      log: *char_dev_log
   invalid:
     - {}
-    - <<: *serial_dev
-      category: ''
-    - <<: *serial_dev
-      type: ''
-    - <<: *serial_dev
-      target: {}
-    - <<: *serial_dev
-      log: {}
-    - <<: *serial_dev
-      src: *char_dev_path_source
-    - <<: *serial_dev
-      type: stdio
-      src: *char_dev_path_source
-    - <<: *serial_dev
-      type: vc
-      src: *char_dev_path_source
-    - <<: *serial_dev
-      type: pty
-      src: *char_dev_net_source
-    - <<: *serial_dev
-      type: pty
-      src: *char_dev_channel_source
-    - <<: *serial_dev
-      type: file
-    - <<: *serial_dev
-      type: file
-      src: *char_dev_net_source
-    - <<: *serial_dev
-      type: file
-      src: *char_dev_channel_source
-    - <<: *serial_dev
-      type: pipe
-    - <<: *serial_dev
-      type: pipe
-      src: *char_dev_net_source
-    - <<: *serial_dev
-      type: pipe
-      src: *char_dev_channel_source
-    - <<: *serial_dev
-      type: dev
-    - <<: *serial_dev
-      type: dev
-      src: *char_dev_net_source
-    - <<: *serial_dev
-      type: dev
-      src: *char_dev_channel_source
-    - <<: *serial_dev
-      type: nmdm
-    - <<: *serial_dev
-      type: nmdm
-      src: *char_dev_net_source
-    - <<: *serial_dev
-      type: nmdm
-      src: *char_dev_channel_source
-    - <<: *serial_dev
-      type: tcp
-    - <<: *serial_dev
-      type: tcp
-      src: *char_dev_path_source
-    - <<: *serial_dev
-      type: tcp
-      src: *char_dev_socket_source
-    - <<: *serial_dev
-      type: tcp
-      src: *char_dev_channel_source
-    - <<: *serial_dev
-      type: unix
-    - <<: *serial_dev
-      type: unix
-      src: *char_dev_path_source
-    - <<: *serial_dev
-      type: unix
-      src: *char_dev_net_source
-    - <<: *serial_dev
-      type: unix
-      src: *char_dev_channel_source
-    - <<: *serial_dev
-      type: spiceport
-    - <<: *serial_dev
-      type: spiceport
-      src: *char_dev_path_source
-    - <<: *serial_dev
-      type: spiceport
-      src: *char_dev_net_source
-    - <<: *serial_dev
-      type: spiceport
-      src: *char_dev_socket_source
+    - source: *char_dev_source
+    - log: *char_dev_log
+    - source: *char_dev_source
+      log: *char_dev_log
 WatchdogDevice:
   valid:
     - model: itco
@@ -1696,26 +2179,81 @@ WatchdogDevice:
     - model: ''
     - <<: *watchdog
       action: ''
-RNGBackend:
+RNGBuiltinBackend:
   valid:
-    - {}
     - model: builtin
+  invalid:
+    - {}
+    - model: ''
+RNGRandomBackend:
+  valid:
     - &rng_backend
       model: random
       path: /dev/urandom
+  invalid:
+    - {}
+    - model: ''
+      path: /dev/urandom
+    - model: ranodm
+      path: ''
+    - model: random
+RNGEGDSocketBackend:
+  valid:
     - model: egd
       type: unix
-      path: /run/egd.sock
+      path: /run/serial.sock
+      mode: bind
+    - model: egd
+      type: unix
+      path: /run/serial.sock
+      mode: connect
+  invalid:
+    - {}
+    - model: ''
+    - model: egd
+      type: ''
+    - model: egd
+      type: unix
+      path: ''
+      mode: bind
+    - model: egd
+      type: unix
+      path: /run/serial.sock
+      mode: ''
+RNGEGDTCPBackend:
+  valid:
+    - model: egd
+      type: tcp
+      host: *ipv4_address
+      service: 23
+      mode: connect
+    - model: egd
+      type: tcp
+      host: *ipv6_address
+      service: 23
+      mode: connect
+  invalid:
+    - {}
+    - model: egd
+      type: tcp
+      host: ''
+      service: 23
       mode: connect
     - model: egd
       type: tcp
       host: *ipv4_address
-      service: 1000
+      service: 0
       mode: connect
-  invalid:
-    - model: ''
-    - model: random
     - model: egd
+      type: tcp
+      host: *ipv4_address
+      service: 65536
+      mode: connect
+    - model: egd
+      type: tcp
+      host: *ipv4_address
+      service: 23
+      mode: ''
 RNGDevice:
   valid:
     - &rng_device
@@ -1731,7 +2269,28 @@ RNGDevice:
       rate: {}
     - <<: *rng_device
       backend: ''
-TPMDevice:
+PassthroughTPM:
+  valid:
+    - &tpm_passthrough
+      type: passthrough
+      dev: /dev/tpm0
+    - <<: *tpm_passthrough
+      model: tpm-tis
+    - <<: *tpm_passthrough
+      model: tpm-crb
+    - <<: *tpm_passthrough
+      model: tpm-spapr
+    - <<: *tpm_passthrough
+      model: tpm-spapr-proxy
+  invalid:
+    - {}
+    - type: ''
+      dev: /dev/tpm0
+    - type: passthrough
+      dev: ''
+    - <<: *tpm_passthrough
+      model: ''
+EmulatedTPM:
   valid:
     - &tpm_emu
       type: emulator
@@ -1743,8 +2302,6 @@ TPMDevice:
       model: tpm-spapr
     - <<: *tpm_emu
       model: tpm-spapr-proxy
-    - type: passthrough
-      dev: /dev/tpm0
     - <<: *tpm_emu
       encryption: 65267a83-2c8c-42e3-95e2-ae9a1fe522a7
     - <<: *tpm_emu
@@ -1764,17 +2321,15 @@ TPMDevice:
   invalid:
     - {}
     - type: ''
-    - type: passthrough
-    - <<: *tpm_emu
-      model: ''
-    - type: passthrough
-      dev: ''
     - <<: *tpm_emu
       encryption: ''
     - <<: *tpm_emu
       version: ''
     - <<: *tpm_emu
       persistent_state: ''
+    - <<: *tpm_emu
+      active_pcr_banks:
+        - ''
 SimpleDevice:
   valid:
     - &simple_dev
@@ -1796,8 +2351,6 @@ DomainInfo:
     - name: test
       type: test
       memory: 65536
-      os:
-        variant: test
-        arch: x86_64
+      os: *test_osinfo
   invalid:
     - {}

--- a/tests/libvirt/models/libvirt_models_domain_test.py
+++ b/tests/libvirt/models/libvirt_models_domain_test.py
@@ -7,18 +7,24 @@ from __future__ import annotations
 
 import pytest
 
-from psutil import cpu_count
 from pydantic import ValidationError
 
-from fvirt.libvirt.models.domain import (CharacterDevice, CharDevLog, CharDevSource, CharDevTarget, ClockInfo, ClockTimerInfo, ControllerDevice,
-                                         ControllerDriverInfo, CPUInfo, CPUModelInfo, CPUTopology, DataRate, Devices, DiskDevice, DiskTargetInfo,
-                                         DiskVolumeSrcInfo, DomainInfo, DriveAddress, FeaturesAPICInfo, FeaturesCapabilities, FeaturesGICInfo,
-                                         FeaturesHyperVInfo, FeaturesHyperVSpinlocks, FeaturesHyperVSTimer, FeaturesHyperVVendorID, FeaturesInfo,
-                                         FeaturesIOAPICInfo, FeaturesKVMDirtyRing, FeaturesKVMInfo, FeaturesTCGInfo, FeaturesXenInfo,
-                                         FeaturesXenPassthrough, Filesystem, FilesystemDriverInfo, GraphicsDevice, GraphicsListener, InputDevice,
-                                         InputSource, MemtuneInfo, NetworkInterface, NetworkIPInfo, NetworkVPort, OSContainerIDMapEntry,
-                                         OSContainerIDMapInfo, OSFWLoaderInfo, OSFWNVRAMInfo, OSInfo, PCIAddress, RNGBackend, RNGDevice,
-                                         SimpleDevice, TPMDevice, VideoDevice, WatchdogDevice)
+from fvirt.libvirt.models.domain import (AddressGraphicsListener, BlockDisk, BridgeInterface, CharacterDevice, CharDevChannelSource, CharDevLog,
+                                         CharDevPathSource, CharDevPTYSource, CharDevSimpleSource, CharDevSocketSource, CharDevTCPSource,
+                                         ClockAbsolute, ClockLocal, ClockTimerInfo, ClockTimezone, ClockUTC, ClockVariable, ConsoleDevTarget,
+                                         ControllerDriverInfo, CPUInfo, CPUModelInfo, CPUTopology, DataRate, Devices, DirectInterface, DiskTargetInfo,
+                                         DiskVolumeSrcInfo, DomainInfo, DriveAddress, EmulatedTPM, EvdevInputDevice, FeaturesAPICInfo,
+                                         FeaturesCapabilities, FeaturesGICInfo, FeaturesHyperVInfo, FeaturesHyperVSpinlocks, FeaturesHyperVSTimer,
+                                         FeaturesHyperVVendorID, FeaturesInfo, FeaturesIOAPICInfo, FeaturesKVMDirtyRing, FeaturesKVMInfo,
+                                         FeaturesSMMConfig, FeaturesTCGInfo, FeaturesXenInfo, FeaturesXenPassthrough, FileDisk, Filesystem,
+                                         FilesystemDriverInfo, IDEController, InputSource, MemtuneInfo, NetChannelDevTarget, NetworkGraphicsListener,
+                                         NetworkIPv4Info, NetworkIPv6Info, NetworkVPort, NullGraphicsListener, NullInterface, OSContainerBootInfo,
+                                         OSContainerIDMapEntry, OSContainerIDMapInfo, OSDirectBootInfo, OSFirmwareInfo, OSFWLoaderInfo, OSFWNVRAMInfo,
+                                         OSHostBootInfo, OSTestBootInfo, ParallelDevTarget, PassthroughInputDevice, PassthroughTPM, PCIAddress,
+                                         RDPGraphics, RNGBuiltinBackend, RNGDevice, RNGEGDSocketBackend, RNGEGDTCPBackend, RNGRandomBackend,
+                                         SCSIController, SerialDevTarget, SimpleController, SimpleDevice, SimpleInputDevice, SocketGraphicsListener,
+                                         SPICEGraphics, USBController, UserInterface, VideoDevice, VirtIOChannelDevTarget, VirtIOSerialController,
+                                         VirtualInterface, VNCGraphics, VolumeDisk, WatchdogDevice, XenBusController, XenChannelDevTarget)
 
 from ...shared import get_test_cases
 
@@ -132,21 +138,6 @@ def test_CPUTopology_check_bad_vcpus() -> None:
         model.check(0)
 
 
-def test_CPUTopology_infer_threads() -> None:
-    '''Check that inferring threads for CPUTopology works.'''
-    lcpus = cpu_count(logical=True)
-    pcpus = cpu_count(logical=False)
-
-    if lcpus is None or pcpus is None:
-        pytest.skip('Unable to infer CPU topology on this system, skipping test.')
-
-    model = CPUTopology(
-        infer='threads',
-    )
-
-    assert model.threads == lcpus // pcpus
-
-
 @pytest.mark.parametrize('d', CASES['CPUInfo']['valid'])
 def test_CPUInfo_valid(d: dict) -> None:
     '''Check validation of known-good CPUInfo dicts.'''
@@ -212,17 +203,69 @@ def test_OSContainerIDMapInfo_invalid(d: dict) -> None:
         OSContainerIDMapInfo.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['OSInfo']['valid'])
-def test_OSInfo_valid(d: dict) -> None:
-    '''Check validation of known-good OSInfo dicts.'''
-    OSInfo.model_validate(d)
+@pytest.mark.parametrize('d', CASES['OSFirmwareInfo']['valid'])
+def test_OSFirmwareInfo_valid(d: dict) -> None:
+    '''Check validation of known-good OSFirmwareInfo dicts.'''
+    OSFirmwareInfo.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['OSInfo']['invalid'])
-def test_OSInfo_invalid(d: dict) -> None:
-    '''Check validation of known-bad OSInfo dicts.'''
+@pytest.mark.parametrize('d', CASES['OSFirmwareInfo']['invalid'])
+def test_OSFirmwareInfo_invalid(d: dict) -> None:
+    '''Check validation of known-bad OSFirmwareInfo dicts.'''
     with pytest.raises(ValidationError):
-        OSInfo.model_validate(d)
+        OSFirmwareInfo.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['OSHostBootInfo']['valid'])
+def test_OSHostBootInfo_valid(d: dict) -> None:
+    '''Check validation of known-good OSHostBootInfo dicts.'''
+    OSHostBootInfo.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['OSHostBootInfo']['invalid'])
+def test_OSHostBootInfo_invalid(d: dict) -> None:
+    '''Check validation of known-bad OSHostBootInfo dicts.'''
+    with pytest.raises(ValidationError):
+        OSHostBootInfo.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['OSDirectBootInfo']['valid'])
+def test_OSDirectBootInfo_valid(d: dict) -> None:
+    '''Check validation of known-good OSDirectBootInfo dicts.'''
+    OSDirectBootInfo.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['OSDirectBootInfo']['invalid'])
+def test_OSDirectBootInfo_invalid(d: dict) -> None:
+    '''Check validation of known-bad OSDirectBootInfo dicts.'''
+    with pytest.raises(ValidationError):
+        OSDirectBootInfo.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['OSContainerBootInfo']['valid'])
+def test_OSContainerBootInfo_valid(d: dict) -> None:
+    '''Check validation of known-good OSContainerBootInfo dicts.'''
+    OSContainerBootInfo.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['OSContainerBootInfo']['invalid'])
+def test_OSContainerBootInfo_invalid(d: dict) -> None:
+    '''Check validation of known-bad OSContainerBootInfo dicts.'''
+    with pytest.raises(ValidationError):
+        OSContainerBootInfo.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['OSTestBootInfo']['valid'])
+def test_OSTestBootInfo_valid(d: dict) -> None:
+    '''Check validation of known-good OSTestBootInfo dicts.'''
+    OSTestBootInfo.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['OSTestBootInfo']['invalid'])
+def test_OSTestBootInfo_invalid(d: dict) -> None:
+    '''Check validation of known-bad OSTestBootInfo dicts.'''
+    with pytest.raises(ValidationError):
+        OSTestBootInfo.model_validate(d)
 
 
 @pytest.mark.parametrize('d', CASES['ClockTimerInfo']['valid'])
@@ -238,17 +281,69 @@ def test_ClockTimerInfo_invalid(d: dict) -> None:
         ClockTimerInfo.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['ClockInfo']['valid'])
-def test_ClockInfo_valid(d: dict) -> None:
-    '''Check validation of known-good ClockInfo dicts.'''
-    ClockInfo.model_validate(d)
+@pytest.mark.parametrize('d', CASES['ClockUTC']['valid'])
+def test_ClockUTC_valid(d: dict) -> None:
+    '''Check validation of known-good ClockUTC dicts.'''
+    ClockUTC.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['ClockInfo']['invalid'])
-def test_ClockInfo_invalid(d: dict) -> None:
-    '''Check validation of known-bad ClockInfo dicts.'''
+@pytest.mark.parametrize('d', CASES['ClockUTC']['invalid'])
+def test_ClockUTC_invalid(d: dict) -> None:
+    '''Check validation of known-bad ClockUTC dicts.'''
     with pytest.raises(ValidationError):
-        ClockInfo.model_validate(d)
+        ClockUTC.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['ClockLocal']['valid'])
+def test_ClockLocal_valid(d: dict) -> None:
+    '''Check validation of known-good ClockLocal dicts.'''
+    ClockLocal.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['ClockLocal']['invalid'])
+def test_ClockLocal_invalid(d: dict) -> None:
+    '''Check validation of known-bad ClockLocal dicts.'''
+    with pytest.raises(ValidationError):
+        ClockLocal.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['ClockTimezone']['valid'])
+def test_ClockTimezone_valid(d: dict) -> None:
+    '''Check validation of known-good ClockTimezone dicts.'''
+    ClockTimezone.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['ClockTimezone']['invalid'])
+def test_ClockTimezone_invalid(d: dict) -> None:
+    '''Check validation of known-bad ClockTimezone dicts.'''
+    with pytest.raises(ValidationError):
+        ClockTimezone.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['ClockVariable']['valid'])
+def test_ClockVariable_valid(d: dict) -> None:
+    '''Check validation of known-good ClockVariable dicts.'''
+    ClockVariable.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['ClockVariable']['invalid'])
+def test_ClockVariable_invalid(d: dict) -> None:
+    '''Check validation of known-bad ClockVariable dicts.'''
+    with pytest.raises(ValidationError):
+        ClockVariable.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['ClockAbsolute']['valid'])
+def test_ClockAbsolute_valid(d: dict) -> None:
+    '''Check validation of known-good ClockAbsolute dicts.'''
+    ClockAbsolute.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['ClockAbsolute']['invalid'])
+def test_ClockAbsolute_invalid(d: dict) -> None:
+    '''Check validation of known-bad ClockAbsolute dicts.'''
+    with pytest.raises(ValidationError):
+        ClockAbsolute.model_validate(d)
 
 
 @pytest.mark.parametrize('d', CASES['FeaturesHyperVSpinlocks']['valid'])
@@ -407,6 +502,19 @@ def test_FeaturesIOAPICInfo_invalid(d: dict) -> None:
         FeaturesIOAPICInfo.model_validate(d)
 
 
+@pytest.mark.parametrize('d', CASES['FeaturesSMMConfig']['valid'])
+def test_FeaturesSMMConfig_valid(d: dict) -> None:
+    '''Check validation of known-good FeaturesSMMConfig dicts.'''
+    FeaturesSMMConfig.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['FeaturesSMMConfig']['invalid'])
+def test_FeaturesSMMConfig_invalid(d: dict) -> None:
+    '''Check validation of known-bad FeaturesSMMConfig dicts.'''
+    with pytest.raises(ValidationError):
+        FeaturesSMMConfig.model_validate(d)
+
+
 @pytest.mark.parametrize('d', CASES['FeaturesCapabilities']['valid'])
 def test_FeaturesCapabilities_valid(d: dict) -> None:
     '''Check validation of known-good FeaturesCapabilities dicts.'''
@@ -446,17 +554,82 @@ def test_ControllerDriverInfo_invalid(d: dict) -> None:
         ControllerDriverInfo.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['ControllerDevice']['valid'])
-def test_ControllerDevice_valid(d: dict) -> None:
-    '''Check validation of known-good ControllerDevice dicts.'''
-    ControllerDevice.model_validate(d)
+@pytest.mark.parametrize('d', CASES['SimpleController']['valid'])
+def test_SimpleController_valid(d: dict) -> None:
+    '''Check validation of known-good SimpleController dicts.'''
+    SimpleController.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['ControllerDevice']['invalid'])
-def test_ControllerDevice_invalid(d: dict) -> None:
-    '''Check validation of known-bad ControllerDevice dicts.'''
+@pytest.mark.parametrize('d', CASES['SimpleController']['invalid'])
+def test_SimpleController_invalid(d: dict) -> None:
+    '''Check validation of known-bad SimpleController dicts.'''
     with pytest.raises(ValidationError):
-        ControllerDevice.model_validate(d)
+        SimpleController.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['XenBusController']['valid'])
+def test_XenBusController_valid(d: dict) -> None:
+    '''Check validation of known-good XenBusController dicts.'''
+    XenBusController.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['XenBusController']['invalid'])
+def test_XenBusController_invalid(d: dict) -> None:
+    '''Check validation of known-bad XenBusController dicts.'''
+    with pytest.raises(ValidationError):
+        XenBusController.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['IDEController']['valid'])
+def test_IDEController_valid(d: dict) -> None:
+    '''Check validation of known-good IDEController dicts.'''
+    IDEController.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['IDEController']['invalid'])
+def test_IDEController_invalid(d: dict) -> None:
+    '''Check validation of known-bad IDEController dicts.'''
+    with pytest.raises(ValidationError):
+        IDEController.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['SCSIController']['valid'])
+def test_SCSIController_valid(d: dict) -> None:
+    '''Check validation of known-good SCSIController dicts.'''
+    SCSIController.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['SCSIController']['invalid'])
+def test_SCSIController_invalid(d: dict) -> None:
+    '''Check validation of known-bad SCSIController dicts.'''
+    with pytest.raises(ValidationError):
+        SCSIController.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['USBController']['valid'])
+def test_USBController_valid(d: dict) -> None:
+    '''Check validation of known-good USBController dicts.'''
+    USBController.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['USBController']['invalid'])
+def test_USBController_invalid(d: dict) -> None:
+    '''Check validation of known-bad USBController dicts.'''
+    with pytest.raises(ValidationError):
+        USBController.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['VirtIOSerialController']['valid'])
+def test_VirtIOSerialController_valid(d: dict) -> None:
+    '''Check validation of known-good VirtIOSerialController dicts.'''
+    VirtIOSerialController.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['VirtIOSerialController']['invalid'])
+def test_VirtIOSerialController_invalid(d: dict) -> None:
+    '''Check validation of known-bad VirtIOSerialController dicts.'''
+    with pytest.raises(ValidationError):
+        VirtIOSerialController.model_validate(d)
 
 
 @pytest.mark.parametrize('d', CASES['DiskVolumeSrcInfo']['valid'])
@@ -485,17 +658,43 @@ def test_DiskTargetInfo_invalid(d: dict) -> None:
         DiskTargetInfo.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['DiskDevice']['valid'])
-def test_DiskDevice_valid(d: dict) -> None:
-    '''Check validation of known-good DiskDevice dicts.'''
-    DiskDevice.model_validate(d)
+@pytest.mark.parametrize('d', CASES['FileDisk']['valid'])
+def test_FileDisk_valid(d: dict) -> None:
+    '''Check validation of known-good FileDisk dicts.'''
+    FileDisk.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['DiskDevice']['invalid'])
-def test_DiskDevice_invalid(d: dict) -> None:
-    '''Check validation of known-bad DiskDevice dicts.'''
+@pytest.mark.parametrize('d', CASES['FileDisk']['invalid'])
+def test_FileDisk_invalid(d: dict) -> None:
+    '''Check validation of known-bad FileDisk dicts.'''
     with pytest.raises(ValidationError):
-        DiskDevice.model_validate(d)
+        FileDisk.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['BlockDisk']['valid'])
+def test_BlockDisk_valid(d: dict) -> None:
+    '''Check validation of known-good BlockDisk dicts.'''
+    BlockDisk.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['BlockDisk']['invalid'])
+def test_BlockDisk_invalid(d: dict) -> None:
+    '''Check validation of known-bad BlockDisk dicts.'''
+    with pytest.raises(ValidationError):
+        BlockDisk.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['VolumeDisk']['valid'])
+def test_VolumeDisk_valid(d: dict) -> None:
+    '''Check validation of known-good VolumeDisk dicts.'''
+    VolumeDisk.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['VolumeDisk']['invalid'])
+def test_VolumeDisk_invalid(d: dict) -> None:
+    '''Check validation of known-bad VolumeDisk dicts.'''
+    with pytest.raises(ValidationError):
+        VolumeDisk.model_validate(d)
 
 
 @pytest.mark.parametrize('d', CASES['FilesystemDriverInfo']['valid'])
@@ -537,30 +736,95 @@ def test_NetworkVPort_invalid(d: dict) -> None:
         NetworkVPort.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['NetworkIPInfo']['valid'])
-def test_NetworkIPInfo_valid(d: dict) -> None:
-    '''Check validation of known-good NetworkIPInfo dicts.'''
-    NetworkIPInfo.model_validate(d)
+@pytest.mark.parametrize('d', CASES['NetworkIPv4Info']['valid'])
+def test_NetworkIPv4Info_valid(d: dict) -> None:
+    '''Check validation of known-good NetworkIPv4Info dicts.'''
+    NetworkIPv4Info.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['NetworkIPInfo']['invalid'])
-def test_NetworkIPInfo_invalid(d: dict) -> None:
-    '''Check validation of known-bad NetworkIPInfo dicts.'''
+@pytest.mark.parametrize('d', CASES['NetworkIPv4Info']['invalid'])
+def test_NetworkIPv4Info_invalid(d: dict) -> None:
+    '''Check validation of known-bad NetworkIPv4Info dicts.'''
     with pytest.raises(ValidationError):
-        NetworkIPInfo.model_validate(d)
+        NetworkIPv4Info.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['NetworkInterface']['valid'])
-def test_NetworkInterface_valid(d: dict) -> None:
-    '''Check validation of known-good NetworkInterface dicts.'''
-    NetworkInterface.model_validate(d)
+@pytest.mark.parametrize('d', CASES['NetworkIPv6Info']['valid'])
+def test_NetworkIPv6Info_valid(d: dict) -> None:
+    '''Check validation of known-good NetworkIPv6Info dicts.'''
+    NetworkIPv6Info.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['NetworkInterface']['invalid'])
-def test_NetworkInterface_invalid(d: dict) -> None:
-    '''Check validation of known-bad NetworkInterface dicts.'''
+@pytest.mark.parametrize('d', CASES['NetworkIPv6Info']['invalid'])
+def test_NetworkIPv6Info_invalid(d: dict) -> None:
+    '''Check validation of known-bad NetworkIPv6Info dicts.'''
     with pytest.raises(ValidationError):
-        NetworkInterface.model_validate(d)
+        NetworkIPv6Info.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['BridgeInterface']['valid'])
+def test_BridgeInterface_valid(d: dict) -> None:
+    '''Check validation of known-good BridgeInterface dicts.'''
+    BridgeInterface.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['BridgeInterface']['invalid'])
+def test_BridgeInterface_invalid(d: dict) -> None:
+    '''Check validation of known-bad BridgeInterface dicts.'''
+    with pytest.raises(ValidationError):
+        BridgeInterface.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['DirectInterface']['valid'])
+def test_DirectInterface_valid(d: dict) -> None:
+    '''Check validation of known-good DirectInterface dicts.'''
+    DirectInterface.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['DirectInterface']['invalid'])
+def test_DirectInterface_invalid(d: dict) -> None:
+    '''Check validation of known-bad DirectInterface dicts.'''
+    with pytest.raises(ValidationError):
+        DirectInterface.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['NullInterface']['valid'])
+def test_NullInterface_valid(d: dict) -> None:
+    '''Check validation of known-good NullInterface dicts.'''
+    NullInterface.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['NullInterface']['invalid'])
+def test_NullInterface_invalid(d: dict) -> None:
+    '''Check validation of known-bad NullInterface dicts.'''
+    with pytest.raises(ValidationError):
+        NullInterface.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['UserInterface']['valid'])
+def test_UserInterface_valid(d: dict) -> None:
+    '''Check validation of known-good UserInterface dicts.'''
+    UserInterface.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['UserInterface']['invalid'])
+def test_UserInterface_invalid(d: dict) -> None:
+    '''Check validation of known-bad UserInterface dicts.'''
+    with pytest.raises(ValidationError):
+        UserInterface.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['VirtualInterface']['valid'])
+def test_VirtualInterface_valid(d: dict) -> None:
+    '''Check validation of known-good VirtualInterface dicts.'''
+    VirtualInterface.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['VirtualInterface']['invalid'])
+def test_VirtualInterface_invalid(d: dict) -> None:
+    '''Check validation of known-bad VirtualInterface dicts.'''
+    with pytest.raises(ValidationError):
+        VirtualInterface.model_validate(d)
 
 
 @pytest.mark.parametrize('d', CASES['InputSource']['valid'])
@@ -576,43 +840,134 @@ def test_InputSource_invalid(d: dict) -> None:
         InputSource.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['InputDevice']['valid'])
-def test_InputDevice_valid(d: dict) -> None:
-    '''Check validation of known-good InputDevice dicts.'''
-    InputDevice.model_validate(d)
+@pytest.mark.parametrize('d', CASES['SimpleInputDevice']['valid'])
+def test_SimpleInputDevice_valid(d: dict) -> None:
+    '''Check validation of known-good SimpleInputDevice dicts.'''
+    SimpleInputDevice.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['InputDevice']['invalid'])
-def test_InputDevice_invalid(d: dict) -> None:
-    '''Check validation of known-bad InputDevice dicts.'''
+@pytest.mark.parametrize('d', CASES['SimpleInputDevice']['invalid'])
+def test_SimpleInputDevice_invalid(d: dict) -> None:
+    '''Check validation of known-bad SimpleInputDevice dicts.'''
     with pytest.raises(ValidationError):
-        InputDevice.model_validate(d)
+        SimpleInputDevice.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['GraphicsListener']['valid'])
-def test_GraphicsListener_valid(d: dict) -> None:
-    '''Check validation of known-good GraphicsListener dicts.'''
-    GraphicsListener.model_validate(d)
+@pytest.mark.parametrize('d', CASES['PassthroughInputDevice']['valid'])
+def test_PassthroughInputDevice_valid(d: dict) -> None:
+    '''Check validation of known-good PassthroughInputDevice dicts.'''
+    PassthroughInputDevice.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['GraphicsListener']['invalid'])
-def test_GraphicsListener_invalid(d: dict) -> None:
-    '''Check validation of known-bad GraphicsListener dicts.'''
+@pytest.mark.parametrize('d', CASES['PassthroughInputDevice']['invalid'])
+def test_PassthroughInputDevice_invalid(d: dict) -> None:
+    '''Check validation of known-bad PassthroughInputDevice dicts.'''
     with pytest.raises(ValidationError):
-        GraphicsListener.model_validate(d)
+        PassthroughInputDevice.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['GraphicsDevice']['valid'])
-def test_GraphicsDevice_valid(d: dict) -> None:
-    '''Check validation of known-good GraphicsDevice dicts.'''
-    GraphicsDevice.model_validate(d)
+@pytest.mark.parametrize('d', CASES['EvdevInputDevice']['valid'])
+def test_EvdevInputDevice_valid(d: dict) -> None:
+    '''Check validation of known-good EvdevInputDevice dicts.'''
+    EvdevInputDevice.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['GraphicsDevice']['invalid'])
-def test_GraphicsDevice_invalid(d: dict) -> None:
-    '''Check validation of known-bad GraphicsDevice dicts.'''
+@pytest.mark.parametrize('d', CASES['EvdevInputDevice']['invalid'])
+def test_EvdevInputDevice_invalid(d: dict) -> None:
+    '''Check validation of known-bad EvdevInputDevice dicts.'''
     with pytest.raises(ValidationError):
-        GraphicsDevice.model_validate(d)
+        EvdevInputDevice.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['NullGraphicsListener']['valid'])
+def test_NullGraphicsListener_valid(d: dict) -> None:
+    '''Check validation of known-good NullGraphicsListener dicts.'''
+    NullGraphicsListener.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['NullGraphicsListener']['invalid'])
+def test_NullGraphicsListener_invalid(d: dict) -> None:
+    '''Check validation of known-bad NullGraphicsListener dicts.'''
+    with pytest.raises(ValidationError):
+        NullGraphicsListener.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['AddressGraphicsListener']['valid'])
+def test_AddressGraphicsListener_valid(d: dict) -> None:
+    '''Check validation of known-good AddressGraphicsListener dicts.'''
+    AddressGraphicsListener.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['AddressGraphicsListener']['invalid'])
+def test_AddressGraphicsListener_invalid(d: dict) -> None:
+    '''Check validation of known-bad AddressGraphicsListener dicts.'''
+    with pytest.raises(ValidationError):
+        AddressGraphicsListener.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['NetworkGraphicsListener']['valid'])
+def test_NetworkGraphicsListener_valid(d: dict) -> None:
+    '''Check validation of known-good NetworkGraphicsListener dicts.'''
+    NetworkGraphicsListener.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['NetworkGraphicsListener']['invalid'])
+def test_NetworkGraphicsListener_invalid(d: dict) -> None:
+    '''Check validation of known-bad NetworkGraphicsListener dicts.'''
+    with pytest.raises(ValidationError):
+        NetworkGraphicsListener.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['SocketGraphicsListener']['valid'])
+def test_SocketGraphicsListener_valid(d: dict) -> None:
+    '''Check validation of known-good SocketGraphicsListener dicts.'''
+    SocketGraphicsListener.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['SocketGraphicsListener']['invalid'])
+def test_SocketGraphicsListener_invalid(d: dict) -> None:
+    '''Check validation of known-bad SocketGraphicsListener dicts.'''
+    with pytest.raises(ValidationError):
+        SocketGraphicsListener.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['VNCGraphics']['valid'])
+def test_VNCGraphics_valid(d: dict) -> None:
+    '''Check validation of known-good VNCGraphics dicts.'''
+    VNCGraphics.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['VNCGraphics']['invalid'])
+def test_VNCGraphics_invalid(d: dict) -> None:
+    '''Check validation of known-bad VNCGraphics dicts.'''
+    with pytest.raises(ValidationError):
+        VNCGraphics.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['SPICEGraphics']['valid'])
+def test_SPICEGraphics_valid(d: dict) -> None:
+    '''Check validation of known-good SPICEGraphics dicts.'''
+    SPICEGraphics.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['SPICEGraphics']['invalid'])
+def test_SPICEGraphics_invalid(d: dict) -> None:
+    '''Check validation of known-bad SPICEGraphics dicts.'''
+    with pytest.raises(ValidationError):
+        SPICEGraphics.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['RDPGraphics']['valid'])
+def test_RDPGraphics_valid(d: dict) -> None:
+    '''Check validation of known-good RDPGraphics dicts.'''
+    RDPGraphics.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['RDPGraphics']['invalid'])
+def test_RDPGraphics_invalid(d: dict) -> None:
+    '''Check validation of known-bad RDPGraphics dicts.'''
+    with pytest.raises(ValidationError):
+        RDPGraphics.model_validate(d)
 
 
 @pytest.mark.parametrize('d', CASES['VideoDevice']['valid'])
@@ -628,30 +983,160 @@ def test_VideoDevice_invalid(d: dict) -> None:
         VideoDevice.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['CharDevSource']['valid'])
-def test_CharDevSource_valid(d: dict) -> None:
-    '''Check validation of known-good CharDevSource dicts.'''
-    CharDevSource.model_validate(d)
+@pytest.mark.parametrize('d', CASES['CharDevSimpleSource']['valid'])
+def test_CharDevSimpleSource_valid(d: dict) -> None:
+    '''Check validation of known-good CharDevSimpleSource dicts.'''
+    CharDevSimpleSource.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['CharDevSource']['invalid'])
-def test_CharDevSource_invalid(d: dict) -> None:
-    '''Check validation of known-bad CharDevSource dicts.'''
+@pytest.mark.parametrize('d', CASES['CharDevSimpleSource']['invalid'])
+def test_CharDevSimpleSource_invalid(d: dict) -> None:
+    '''Check validation of known-bad CharDevSimpleSource dicts.'''
     with pytest.raises(ValidationError):
-        CharDevSource.model_validate(d)
+        CharDevSimpleSource.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['CharDevTarget']['valid'])
-def test_CharDevTarget_valid(d: dict) -> None:
-    '''Check validation of known-good CharDevTarget dicts.'''
-    CharDevTarget.model_validate(d)
+@pytest.mark.parametrize('d', CASES['CharDevPathSource']['valid'])
+def test_CharDevPathSource_valid(d: dict) -> None:
+    '''Check validation of known-good CharDevPathSource dicts.'''
+    CharDevPathSource.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['CharDevTarget']['invalid'])
-def test_CharDevTarget_invalid(d: dict) -> None:
-    '''Check validation of known-bad CharDevTarget dicts.'''
+@pytest.mark.parametrize('d', CASES['CharDevPathSource']['invalid'])
+def test_CharDevPathSource_invalid(d: dict) -> None:
+    '''Check validation of known-bad CharDevPathSource dicts.'''
     with pytest.raises(ValidationError):
-        CharDevTarget.model_validate(d)
+        CharDevPathSource.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['CharDevPTYSource']['valid'])
+def test_CharDevPTYSource_valid(d: dict) -> None:
+    '''Check validation of known-good CharDevPTYSource dicts.'''
+    CharDevPTYSource.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['CharDevPTYSource']['invalid'])
+def test_CharDevPTYSource_invalid(d: dict) -> None:
+    '''Check validation of known-bad CharDevPTYSource dicts.'''
+    with pytest.raises(ValidationError):
+        CharDevPTYSource.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['CharDevSocketSource']['valid'])
+def test_CharDevSocketSource_valid(d: dict) -> None:
+    '''Check validation of known-good CharDevSocketSource dicts.'''
+    CharDevSocketSource.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['CharDevSocketSource']['invalid'])
+def test_CharDevSocketSource_invalid(d: dict) -> None:
+    '''Check validation of known-bad CharDevSocketSource dicts.'''
+    with pytest.raises(ValidationError):
+        CharDevSocketSource.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['CharDevTCPSource']['valid'])
+def test_CharDevTCPSource_valid(d: dict) -> None:
+    '''Check validation of known-good CharDevTCPSource dicts.'''
+    CharDevTCPSource.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['CharDevTCPSource']['invalid'])
+def test_CharDevTCPSource_invalid(d: dict) -> None:
+    '''Check validation of known-bad CharDevTCPSource dicts.'''
+    with pytest.raises(ValidationError):
+        CharDevTCPSource.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['CharDevChannelSource']['valid'])
+def test_CharDevChannelSource_valid(d: dict) -> None:
+    '''Check validation of known-good CharDevChannelSource dicts.'''
+    CharDevChannelSource.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['CharDevChannelSource']['invalid'])
+def test_CharDevChannelSource_invalid(d: dict) -> None:
+    '''Check validation of known-bad CharDevChannelSource dicts.'''
+    with pytest.raises(ValidationError):
+        CharDevChannelSource.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['ParallelDevTarget']['valid'])
+def test_ParallelDevTarget_valid(d: dict) -> None:
+    '''Check validation of known-good ParallelDevTarget dicts.'''
+    ParallelDevTarget.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['ParallelDevTarget']['invalid'])
+def test_ParallelDevTarget_invalid(d: dict) -> None:
+    '''Check validation of known-bad ParallelDevTarget dicts.'''
+    with pytest.raises(ValidationError):
+        ParallelDevTarget.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['SerialDevTarget']['valid'])
+def test_SerialDevTarget_valid(d: dict) -> None:
+    '''Check validation of known-good SerialDevTarget dicts.'''
+    SerialDevTarget.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['SerialDevTarget']['invalid'])
+def test_SerialDevTarget_invalid(d: dict) -> None:
+    '''Check validation of known-bad SerialDevTarget dicts.'''
+    with pytest.raises(ValidationError):
+        SerialDevTarget.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['ConsoleDevTarget']['valid'])
+def test_ConsoleDevTarget_valid(d: dict) -> None:
+    '''Check validation of known-good ConsoleDevTarget dicts.'''
+    ConsoleDevTarget.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['ConsoleDevTarget']['invalid'])
+def test_ConsoleDevTarget_invalid(d: dict) -> None:
+    '''Check validation of known-bad ConsoleDevTarget dicts.'''
+    with pytest.raises(ValidationError):
+        ConsoleDevTarget.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['NetChannelDevTarget']['valid'])
+def test_NetChannelDevTarget_valid(d: dict) -> None:
+    '''Check validation of known-good NetChannelDevTarget dicts.'''
+    NetChannelDevTarget.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['NetChannelDevTarget']['invalid'])
+def test_NetChannelDevTarget_invalid(d: dict) -> None:
+    '''Check validation of known-bad NetChannelDevTarget dicts.'''
+    with pytest.raises(ValidationError):
+        NetChannelDevTarget.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['VirtIOChannelDevTarget']['valid'])
+def test_VirtIOChannelDevTarget_valid(d: dict) -> None:
+    '''Check validation of known-good VirtIOChannelDevTarget dicts.'''
+    VirtIOChannelDevTarget.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['VirtIOChannelDevTarget']['invalid'])
+def test_VirtIOChannelDevTarget_invalid(d: dict) -> None:
+    '''Check validation of known-bad VirtIOChannelDevTarget dicts.'''
+    with pytest.raises(ValidationError):
+        VirtIOChannelDevTarget.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['XenChannelDevTarget']['valid'])
+def test_XenChannelDevTarget_valid(d: dict) -> None:
+    '''Check validation of known-good XenChannelDevTarget dicts.'''
+    XenChannelDevTarget.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['XenChannelDevTarget']['invalid'])
+def test_XenChannelDevTarget_invalid(d: dict) -> None:
+    '''Check validation of known-bad XenChannelDevTarget dicts.'''
+    with pytest.raises(ValidationError):
+        XenChannelDevTarget.model_validate(d)
 
 
 @pytest.mark.parametrize('d', CASES['CharDevLog']['valid'])
@@ -693,17 +1178,56 @@ def test_WatchdogDevice_invalid(d: dict) -> None:
         WatchdogDevice.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['RNGBackend']['valid'])
-def test_RNGBackend_valid(d: dict) -> None:
-    '''Check validation of known-good RNGBackend dicts.'''
-    RNGBackend.model_validate(d)
+@pytest.mark.parametrize('d', CASES['RNGBuiltinBackend']['valid'])
+def test_RNGBuiltinBackend_valid(d: dict) -> None:
+    '''Check validation of known-good RNGBuiltinBackend dicts.'''
+    RNGBuiltinBackend.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['RNGBackend']['invalid'])
-def test_RNGBackend_invalid(d: dict) -> None:
-    '''Check validation of known-bad RNGBackend dicts.'''
+@pytest.mark.parametrize('d', CASES['RNGBuiltinBackend']['invalid'])
+def test_RNGBuiltinBackend_invalid(d: dict) -> None:
+    '''Check validation of known-bad RNGBuiltinBackend dicts.'''
     with pytest.raises(ValidationError):
-        RNGBackend.model_validate(d)
+        RNGBuiltinBackend.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['RNGRandomBackend']['valid'])
+def test_RNGRandomBackend_valid(d: dict) -> None:
+    '''Check validation of known-good RNGRandomBackend dicts.'''
+    RNGRandomBackend.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['RNGRandomBackend']['invalid'])
+def test_RNGRandomBackend_invalid(d: dict) -> None:
+    '''Check validation of known-bad RNGRandomBackend dicts.'''
+    with pytest.raises(ValidationError):
+        RNGRandomBackend.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['RNGEGDSocketBackend']['valid'])
+def test_RNGEGDSocketBackend_valid(d: dict) -> None:
+    '''Check validation of known-good RNGEGDSocketBackend dicts.'''
+    RNGEGDSocketBackend.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['RNGEGDSocketBackend']['invalid'])
+def test_RNGEGDSocketBackend_invalid(d: dict) -> None:
+    '''Check validation of known-bad RNGEGDSocketBackend dicts.'''
+    with pytest.raises(ValidationError):
+        RNGEGDSocketBackend.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['RNGEGDTCPBackend']['valid'])
+def test_RNGEGDTCPBackend_valid(d: dict) -> None:
+    '''Check validation of known-good RNGEGDTCPBackend dicts.'''
+    RNGEGDTCPBackend.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['RNGEGDTCPBackend']['invalid'])
+def test_RNGEGDTCPBackend_invalid(d: dict) -> None:
+    '''Check validation of known-bad RNGEGDTCPBackend dicts.'''
+    with pytest.raises(ValidationError):
+        RNGEGDTCPBackend.model_validate(d)
 
 
 @pytest.mark.parametrize('d', CASES['RNGDevice']['valid'])
@@ -719,17 +1243,30 @@ def test_RNGDevice_invalid(d: dict) -> None:
         RNGDevice.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['TPMDevice']['valid'])
-def test_TPMDevice_valid(d: dict) -> None:
-    '''Check validation of known-good TPMDevice dicts.'''
-    TPMDevice.model_validate(d)
+@pytest.mark.parametrize('d', CASES['PassthroughTPM']['valid'])
+def test_PassthroughTPM_valid(d: dict) -> None:
+    '''Check validation of known-good PassthroughTPM dicts.'''
+    PassthroughTPM.model_validate(d)
 
 
-@pytest.mark.parametrize('d', CASES['TPMDevice']['invalid'])
-def test_TPMDevice_invalid(d: dict) -> None:
-    '''Check validation of known-bad TPMDevice dicts.'''
+@pytest.mark.parametrize('d', CASES['PassthroughTPM']['invalid'])
+def test_PassthroughTPM_invalid(d: dict) -> None:
+    '''Check validation of known-bad PassthroughTPM dicts.'''
     with pytest.raises(ValidationError):
-        TPMDevice.model_validate(d)
+        PassthroughTPM.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['EmulatedTPM']['valid'])
+def test_EmulatedTPM_valid(d: dict) -> None:
+    '''Check validation of known-good EmulatedTPM dicts.'''
+    EmulatedTPM.model_validate(d)
+
+
+@pytest.mark.parametrize('d', CASES['EmulatedTPM']['invalid'])
+def test_EmulatedTPM_invalid(d: dict) -> None:
+    '''Check validation of known-bad EmulatedTPM dicts.'''
+    with pytest.raises(ValidationError):
+        EmulatedTPM.model_validate(d)
 
 
 @pytest.mark.parametrize('d', CASES['SimpleDevice']['valid'])

--- a/tests/libvirt/models/libvirt_models_types_test.py
+++ b/tests/libvirt/models/libvirt_models_types_test.py
@@ -5,11 +5,13 @@
 
 from __future__ import annotations
 
+import datetime
+
 from typing import Type
 
 import pytest
 
-from fvirt.libvirt.models._types import CustomBool, OnOff, YesNo
+from fvirt.libvirt.models._types import CustomBool, OnOff, Timestamp, YesNo
 
 
 @pytest.mark.parametrize('t, true_str, false_str', (
@@ -32,3 +34,18 @@ def test_custom_bools(t: Type[CustomBool], true_str: str, false_str: str) -> Non
     assert hash(t(false_str)) == hash(False)
     assert hash(t(True)) == hash(True)
     assert hash(t(False)) == hash(False)
+
+
+@pytest.mark.parametrize('v, t, e', (
+    (0, int, 0),
+    (0, float, 0.0),
+    (0, str, '1970-01-01T00:00:00'),
+    ('1970-01-01T00:00:00Z', int, 0),
+    ('1970-01-01T00:00:00Z', float, 0.0),
+    ('1970-01-01T00:00:00Z', str, '1970-01-01T00:00:00'),
+))
+def test_Timestamp(v: int | str | datetime.datetime, t: Type[int | str | float], e: int | str | float) -> None:
+    '''Check conversion handling for Timestamps.'''
+    tstamp = Timestamp(v)
+
+    assert t(tstamp) == e


### PR DESCRIPTION
- Add descriptions to (almost) all fields.
- Add custom types to handle some of the peculiarities of libvirt XML in a way that is more user-friendly.
- Make appropriate usage of discriminated unions instead of unified models with opaque model validators.