### PR TITLE
Fix up handling of package version number.

### DIFF
--- a/fvirt/__init__.py
+++ b/fvirt/__init__.py
@@ -5,10 +5,16 @@
 
 import sys
 
-from .version import VERSION
+from typing import Final
+
+from .version import VersionNumber
 
 if not sys.version_info >= (3, 11):  # pragma: no cover # By definition this can never be covered by pytest
     raise RuntimeError('fvirt requires Python 3.11 or newer.')
+
+__version__: Final = '0.0.1'
+
+VERSION: Final = VersionNumber.from_string(__version__)
 
 __all__ = [
     'VERSION',

--- a/fvirt/commands/version.py
+++ b/fvirt/commands/version.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING, Final
 import click
 
 from ._base.command import Command
+from .. import VERSION
 from ..libvirt import API_VERSION
-from ..version import VERSION
 
 if TYPE_CHECKING:
     from ._base.state import State

--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -7,18 +7,12 @@ import pytest
 
 import fvirt
 
-from fvirt.version import VERSION, VersionNumber
-
-
-def test_version_in_init() -> None:
-    '''Confirm that VERSION is also in the __init__ module.'''
-    assert hasattr(fvirt, 'VERSION')
-    assert fvirt.VERSION == VERSION
+from fvirt.version import VersionNumber
 
 
 def test_version_type() -> None:
     '''Confirm that VERSION is a VersionNumber.'''
-    assert isinstance(VERSION, VersionNumber)
+    assert isinstance(fvirt.VERSION, VersionNumber)
 
 
 def test_equality() -> None:
@@ -68,7 +62,7 @@ def test_invalid_args() -> None:
 
 def test_version_str() -> None:
     '''Test that conversion to a string works correctly.'''
-    assert str(VERSION) == f'{ VERSION.major }.{ VERSION.minor }.{ VERSION.release }'
+    assert str(fvirt.VERSION) == f'{ fvirt.VERSION.major }.{ fvirt.VERSION.minor }.{ fvirt.VERSION.release }'
 
 
 def test_version_hash() -> None:


### PR DESCRIPTION
Provide `__version__` at top level to better interface with other tools, and derive `VERSION` from that.