### PR TITLE
Restructure imports to improve load times.

### DIFF
--- a/fvirt/cli.py
+++ b/fvirt/cli.py
@@ -120,13 +120,11 @@ can be viewed by running 'fvirt schema config'.
 '''.lstrip().rstrip()
 
 FVIRT_HELP = '''
-A lightweight frontend for libvirt.
+A command-line frontend for libvirt.
 
-Most commands are grouped by the type of libvirt object they
-operate on.
+Most commands are grouped by the type of libvirt object they operate on.
 
-For more information about a specific command, run that `fvirt
-help COMMAND`.
+For more information about a specific command, run `fvirt help COMMAND`.
 '''.lstrip().rstrip()
 
 

--- a/fvirt/commands/_base/autostart.py
+++ b/fvirt/commands/_base/autostart.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import logging
 
-from collections.abc import Sequence
 from textwrap import dedent
 from typing import TYPE_CHECKING, Final, Self, cast
 
@@ -16,9 +15,6 @@ import click
 from .exitcode import ExitCode
 from .match import MatchArgument, MatchCommand, get_match_or_entity
 from .objects import is_object_mixin
-from ...libvirt import InsufficientPrivileges
-from ...libvirt.entity import RunnableEntity
-from ...util.report import summary
 
 if TYPE_CHECKING:
     from .state import State
@@ -47,7 +43,20 @@ class AutostartCommand(MatchCommand):
             ),
         )
 
-        def cb(ctx: click.Context, state: State, /, match: MatchArgument, entity: str | None, enable: bool) -> None:
+        def cb(
+            ctx: click.Context,
+            state: State,
+            /,
+            match: MatchArgument,
+            entity: str | None,
+            enable: bool
+        ) -> None:
+            from collections.abc import Sequence
+
+            from ...libvirt.entity import RunnableEntity
+            from ...libvirt.exceptions import InsufficientPrivileges
+            from ...util.report import summary
+
             with state.hypervisor as hv:
                 entities = cast(Sequence[RunnableEntity], get_match_or_entity(
                     obj=self,

--- a/fvirt/commands/_base/lifecycle.py
+++ b/fvirt/commands/_base/lifecycle.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import concurrent.futures
 import logging
 
 from abc import ABC, abstractmethod
@@ -18,9 +17,6 @@ import click
 from .exitcode import ExitCode
 from .match import MatchArgument, MatchCommand, get_match_or_entity
 from .objects import is_object_mixin
-from ...libvirt import InvalidOperation, LifecycleResult
-from ...libvirt.runner import RunnerResult, run_entity_method, run_sub_entity_method
-from ...util.report import summary
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -80,6 +76,13 @@ class LifecycleCommand(MatchCommand):
             *args: Any,
             **kwargs: Any
         ) -> None:
+            import concurrent.futures
+
+            from ...libvirt.entity import LifecycleResult
+            from ...libvirt.exceptions import InvalidOperation
+            from ...libvirt.runner import RunnerResult, run_entity_method, run_sub_entity_method
+            from ...util.report import summary
+
             if op_help.idempotent_state:
                 kwargs['idempotent'] = state.idempotent
 

--- a/fvirt/commands/_base/match.py
+++ b/fvirt/commands/_base/match.py
@@ -12,12 +12,9 @@ from typing import TYPE_CHECKING, Any, Concatenate, Final, ParamSpec, Self, Type
 
 import click
 
-from lxml import etree
-
 from .command import Command
 from .exitcode import ExitCode
 from .objects import ObjectMixin, is_object_mixin
-from ...libvirt.entity import Entity
 from ...util.match import MatchAlias, MatchArgument, MatchTarget
 
 if TYPE_CHECKING:
@@ -25,6 +22,7 @@ if TYPE_CHECKING:
 
     from .state import State
     from ...libvirt import Hypervisor
+    from ...libvirt.entity import Entity
 
 P = ParamSpec('P')
 T = TypeVar('T')
@@ -52,6 +50,8 @@ def MatchTargetParam(aliases: Mapping[str, MatchAlias]) -> Type[click.ParamType]
                 if value in aliases:
                     ret = MatchTarget(property=aliases[value].property)
                 else:
+                    from lxml import etree
+
                     ret = MatchTarget(xpath=etree.XPath(value, smart_strings=False))
             else:
                 ret = value

--- a/fvirt/commands/_base/objects.py
+++ b/fvirt/commands/_base/objects.py
@@ -14,13 +14,12 @@ from typing import TYPE_CHECKING, Any, Final, Self, Type, TypeGuard, cast
 import click
 
 from .exitcode import ExitCode
-from ...libvirt.entity import Entity
-from ...libvirt.entity_access import EntityAccess
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping, Sequence
 
     from ...libvirt import Hypervisor
+    from ...libvirt.entity import Entity
     from ...util.match import MatchArgument
 
 LOGGER: Final = logging.getLogger(__name__)
@@ -160,6 +159,9 @@ class ObjectMixin(ABC):
 
     def get_entity(self: Self, ctx: click.Context, parent: Entity | Hypervisor, ident: Any) -> Entity:
         '''Look up an entity based on an identifier.'''
+        from ...libvirt.entity import Entity
+        from ...libvirt.entity_access import EntityAccess
+
         entity = cast(EntityAccess[Entity], getattr(parent, self.LOOKUP_ATTR)).get(ident)
 
         if entity is None:
@@ -170,6 +172,9 @@ class ObjectMixin(ABC):
 
     def get_parent_obj(self: Self, ctx: click.Context, hv: Hypervisor, parent_ident: Any) -> Entity:
         '''Look up the parent object.'''
+        from ...libvirt.entity import Entity
+        from ...libvirt.entity_access import EntityAccess
+
         if self.PARENT_ATTR is None or self.PARENT_NAME is None:
             raise RuntimeError
 
@@ -189,6 +194,8 @@ class ObjectMixin(ABC):
 
     def match_entities(self: Self, ctx: click.Context, parent: Entity | Hypervisor, match: MatchArgument) -> Iterable[Entity]:
         '''Match a set of entities.'''
+        from ...libvirt.entity_access import EntityAccess
+
         return cast(EntityAccess, getattr(parent, self.LOOKUP_ATTR)).match(match)
 
     def match_sub_entities(self: Self, ctx: click.Context, hv: Hypervisor, parent_ident: Any, match: MatchArgument) -> Iterable[Entity]:

--- a/fvirt/commands/_base/tables.py
+++ b/fvirt/commands/_base/tables.py
@@ -7,14 +7,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Final, Self, Type
 
-import click
-
-from .objects import DisplayProperty
 from .terminal import get_terminal
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping, Sequence
 
+    import click
+
+    from .objects import DisplayProperty
     from ...libvirt.entity import Entity
 
 
@@ -28,6 +28,8 @@ def ColumnsParam(cols: Mapping[str, DisplayProperty], type_name: str, /) -> Type
        The resultant class can be used with the `type` argument for
        click.option decorators to properly parse a list of columns for
        a command option.'''
+    import click
+
     class ColumnsParam(click.ParamType):
         name = type_name
 

--- a/fvirt/commands/_base/xslt.py
+++ b/fvirt/commands/_base/xslt.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import concurrent.futures
 import logging
 
 from textwrap import dedent
@@ -13,14 +12,10 @@ from typing import TYPE_CHECKING, Final, Self
 
 import click
 
-from lxml import etree
-
 from .exitcode import ExitCode
 from .match import MatchCommand, get_match_or_entity
 from .objects import is_object_mixin
-from ...libvirt.runner import RunnerResult, run_entity_method, run_sub_entity_method
 from ...util.match import MatchArgument
-from ...util.report import summary
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -52,6 +47,13 @@ class XSLTCommand(MatchCommand):
                 xslt: str,
                 parent: str | None = None
         ) -> None:
+            import concurrent.futures
+
+            from lxml import etree
+
+            from ...libvirt.runner import RunnerResult, run_entity_method, run_sub_entity_method
+            from ...util.report import summary
+
             xform = etree.XSLT(etree.parse(xslt))
 
             with state.hypervisor as hv:

--- a/fvirt/commands/domain/__init__.py
+++ b/fvirt/commands/domain/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Final
 
 from .._base.group import Group
-from ...libvirt import Domain
+from ...libvirt.domain import Domain
 
 domain: Final = Group(
     name='domain',

--- a/fvirt/commands/domain/_mixin.py
+++ b/fvirt/commands/domain/_mixin.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Self, Type
 from .._base.objects import DisplayProperty, ObjectMixin
 from .._base.tables import color_bool, color_optional
 from .._base.terminal import get_terminal
-from ...libvirt import Domain, DomainState
+from ...libvirt.domain import Domain, DomainState
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence

--- a/fvirt/commands/pool/_mixin.py
+++ b/fvirt/commands/pool/_mixin.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Self, Type
 from .._base.objects import DisplayProperty, ObjectMixin
 from .._base.tables import color_bool, color_optional
 from .._base.terminal import get_terminal
-from ...libvirt import StoragePool, StoragePoolState
+from ...libvirt.storage_pool import StoragePool, StoragePoolState
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence

--- a/fvirt/commands/version.py
+++ b/fvirt/commands/version.py
@@ -7,13 +7,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Final
 
-import click
-
 from ._base.command import Command
-from .. import VERSION
-from ..libvirt import API_VERSION
 
 if TYPE_CHECKING:
+    import click
+
     from ._base.state import State
 
 HELP: Final = '''
@@ -22,6 +20,11 @@ Print version information for fvirt.
 
 
 def cb(ctx: click.Context, state: State) -> None:
+    import click
+
+    from .. import VERSION
+    from ..libvirt import API_VERSION
+
     click.echo(f'fvirt { VERSION }, using libvirt-python { API_VERSION }')
 
 

--- a/fvirt/commands/volume/_mixin.py
+++ b/fvirt/commands/volume/_mixin.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Self, Type
 
 from .._base.objects import DisplayProperty, ObjectMixin
 from .._base.tables import color_optional
-from ...libvirt import Volume
+from ...libvirt.volume import Volume
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence

--- a/fvirt/libvirt/events.py
+++ b/fvirt/libvirt/events.py
@@ -6,19 +6,21 @@
 from __future__ import annotations
 
 import logging
-import threading
 
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
-import libvirt
-
-from .exceptions import call_libvirt
+if TYPE_CHECKING:
+    import threading
 
 LOGGER: Final = logging.getLogger(__name__)
 
 
 def _event_loop_thread() -> None:
     '''Thread body for the thread returned by start_libvirt_event_thread.'''
+    import libvirt
+
+    from .exceptions import call_libvirt
+
     while True:
         call_libvirt(lambda: libvirt.virEventRunDefaultImpl())
 
@@ -38,6 +40,12 @@ def start_libvirt_event_thread() -> threading.Thread:
        function exactly once prior to establishing your first Hypervisor
        connection, otherwise reconnect handling will not work correctly
        (among other things).'''
+    import threading
+
+    import libvirt
+
+    from .exceptions import call_libvirt
+
     LOGGER.info('Starting libvirt event handling thread')
     call_libvirt(lambda: libvirt.virEventRegisterDefaultImpl())
     call_libvirt(lambda: libvirt.virEventAddTimeout(60000, _event_dummy_timer_cb, None))

--- a/fvirt/libvirt/hypervisor.py
+++ b/fvirt/libvirt/hypervisor.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import logging
-import threading
 
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Final, Self, cast
@@ -164,6 +163,8 @@ class Hypervisor:
        The underlying libvirt APIs are all concurrent-access safe
        irrespective of the concurrency model in use.'''
     def __init__(self: Self, /, hvuri: URI, *, read_only: bool = False) -> None:
+        import threading
+
         from .domain import DomainAccess
         from .storage_pool import StoragePoolAccess
 

--- a/fvirt/libvirt/models/domain.py
+++ b/fvirt/libvirt/models/domain.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import logging
 
-from collections.abc import Mapping, Sequence
 from ipaddress import IPv4Address, IPv6Address
 from typing import Annotated, Final, Literal, Self
 from uuid import UUID
@@ -405,11 +404,11 @@ class OSContainerBootInfo(_BaseOSInfo):
     init: FilePath = Field(
         description='Absolute path within the container to the init process for the container.',
     )
-    initargs: Sequence[str] = Field(
+    initargs: list[str] = Field(
         default_factory=list,
         description='List of arguments to pass to the init process on startup.',
     )
-    initenv: Mapping[NonEmptyString, str | int | float] = Field(
+    initenv: dict[NonEmptyString, str | int | float] = Field(
         default_factory=dict,
         description='Mapping of environment variables to use when launching the init process.',
     )
@@ -464,7 +463,7 @@ class ClockTimerInfo(Model):
 
 class _BaseClock(Model):
     '''Shared fields for all clock configurations.'''
-    timers: Sequence[ClockTimerInfo] = Field(
+    timers: list[ClockTimerInfo] = Field(
         default_factory=list,
         description='A list of clock timer configuration items.',
     )
@@ -803,7 +802,7 @@ class FeaturesCapabilities(Model):
     policy: Literal['default', 'allow', 'deny'] = Field(
         description='Specify the default policy for domain capabilities.',
     )
-    modify: Mapping[NonEmptyString, V_OnOff] = Field(
+    modify: dict[NonEmptyString, V_OnOff] = Field(
         default_factory=dict,
         description='Specify individual overrides for the default policy. Keys should be capability names, values should indicate whether that ' +
                     'capability will be enabled for the domain or not. If not specified or left empty, the default policy will be followed for ' +
@@ -1438,7 +1437,7 @@ GraphicsListener = Annotated[AddressGraphicsListener | NetworkGraphicsListener |
 
 class _RemoteGraphics(Model):
     '''Base model for graphics output interfaces that utilizes a remote connection.'''
-    listeners: Sequence[GraphicsListener] = Field(
+    listeners: list[GraphicsListener] = Field(
         default_factory=list,
         description='A list of listeners for the device.',
     )
@@ -1531,7 +1530,7 @@ class SPICEGraphics(_RemoteGraphics, _KeymapGraphicsMixin):
         default=None,
         description='The default channel security policy. If not specified, the hypervisor default will be used.',
     )
-    channels: Mapping[str, Literal['secure', 'insecure']] = Field(
+    channels: dict[str, Literal['secure', 'insecure']] = Field(
         default_factory=dict,
         description='Overrides for the defaault channel policy. Keys are channel names, ' +
                     'while each value is the security policy for the associated channel.',
@@ -1849,7 +1848,7 @@ class EmulatedTPM(_BaseTPM):
         default=False,
         description='Whether the TPM state should be kept or not when a transient domain is powered off.',
     )
-    active_pcr_banks: Sequence[Annotated[str, Field(min_length=1)]] = Field(
+    active_pcr_banks: list[Annotated[str, Field(min_length=1)]] = Field(
         default_factory=list,
         description='A list of PCR banks to activate on VM startup. If not specified, active PCR banks will not be modified on startup. ' +
                     'Duplicate entries in this list will be removed automatically.',
@@ -1873,55 +1872,55 @@ class SimpleDevice(Model):
 
 class Devices(Model):
     '''Model representing device configuration for a domain.'''
-    controllers: Sequence[ControllerDevice] = Field(
+    controllers: list[ControllerDevice] = Field(
         default_factory=list,
         description='A list of controller devices for the domain.',
     )
-    disks: Sequence[DiskDevice] = Field(
+    disks: list[DiskDevice] = Field(
         default_factory=list,
         description='A list of disk devices for the domain.',
     )
-    fs: Sequence[Filesystem] = Field(
+    fs: list[Filesystem] = Field(
         default_factory=list,
         description='A list of filesystems for the domain.',
     )
-    net: Sequence[NetworkInterface] = Field(
+    net: list[NetworkInterface] = Field(
         default_factory=list,
         description='A list of network interfaces for the domain.',
     )
-    input: Sequence[InputDevice] = Field(
+    input: list[InputDevice] = Field(
         default_factory=list,
         description='A list of input devices for the domain.',
     )
-    graphics: Sequence[GraphicsDevice] = Field(
+    graphics: list[GraphicsDevice] = Field(
         default_factory=list,
         description='A list of graphics output devices for the domain.',
     )
-    video: Sequence[VideoDevice] = Field(
+    video: list[VideoDevice] = Field(
         default_factory=list,
         description='A list of GPU devices for the domain.',
     )
-    chardev: Sequence[CharacterDevice] = Field(
+    chardev: list[CharacterDevice] = Field(
         default_factory=list,
         description='A list of character devices for the domain.',
     )
-    watchdog: Sequence[WatchdogDevice] = Field(
+    watchdog: list[WatchdogDevice] = Field(
         default_factory=list,
         description='A list of watchdog devices for the domain.',
     )
-    rng: Sequence[RNGDevice] = Field(
+    rng: list[RNGDevice] = Field(
         default_factory=list,
         description='A list of RNG devices for the domain.',
     )
-    tpm: Sequence[TPMDevice] = Field(
+    tpm: list[TPMDevice] = Field(
         default_factory=list,
         description='A list of TPM devices for the domain.',
     )
-    memballoon: Sequence[SimpleDevice] = Field(
+    memballoon: list[SimpleDevice] = Field(
         default_factory=list,
         description='A list of memory balloon devices for the domain.',
     )
-    panic: Sequence[SimpleDevice] = Field(
+    panic: list[SimpleDevice] = Field(
         default_factory=list,
         description='A list of crash notifier devices for the domain.',
     )

--- a/fvirt/libvirt/models/storage_pool.py
+++ b/fvirt/libvirt/models/storage_pool.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import functools
 
-from collections.abc import Sequence
 from ipaddress import IPv4Address, IPv6Address
 from typing import Annotated, Final, Self
 from uuid import UUID
@@ -152,13 +151,13 @@ class PoolSource(Model):
         description='Directory on the remote server to use for storing volumes. ' +
                     f'Only supported for pools of the following types: {", ".join(SOURCE_DIR_TYPES)}',
     )
-    devices: Sequence[NonEmptyString] | None = Field(
+    devices: list[NonEmptyString] | None = Field(
         default=None,
         min_length=1,
         description='A list of devices used to store pool data. ' +
                     f'Only supported for pools of the following types: {", ".join(SOURCE_DEVICE_TYPES | OPTIONAL_SOURCE_DEVICE_TYPES)}',
     )
-    hosts: Sequence[Hostname | IPv4Address | IPv6Address] | None = Field(
+    hosts: list[Hostname | IPv4Address | IPv6Address] | None = Field(
         default=None,
         min_length=1,
         description='A list of network hosts used to store pool data. ' +

--- a/fvirt/templates/__init__.py
+++ b/fvirt/templates/__init__.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 
 import logging
 
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
-import jinja2
+if TYPE_CHECKING:
+    import jinja2
 
 LOGGER: Final = logging.getLogger(__name__)
 
@@ -25,6 +26,8 @@ def get_environment() -> jinja2.Environment:
        be returned each time. If you expect to do a lot of templating,
        it’s more efficient to call this once and cache the result
        yourself.'''
+    import jinja2
+
     return jinja2.Environment(
         loader=jinja2.PackageLoader('fvirt', 'templates'),
         autoescape=jinja2.select_autoescape(),


### PR DESCRIPTION
Many of our imports are only needed when specific functions are run. By restructuring things so that those imports are made only when needed, instead of always being made at the top of the file, load times for the fvirt CLI tool can be improved significantly, especially when displaying help text.

This cuts the execution time of `fvirt help` by more than 50%.